### PR TITLE
Make it work as an extension to gh cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get the version in cargo
+        id: cargo_ver
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | cut -d '"' -f 2)
+          echo ${VERSION}
+          echo v=v${VERSION} >>$GITHUB_OUTPUT
+          test ${GITHUB_REF/refs\/tags\//} = v${VERSION}
+  release-linux:
+    needs: check-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cli/gh-extension-precompile@v1
+        with:
+          build_script_override: "./script/build.sh"
+  release-macos:
+    needs: release-linux
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build for Intel macOS
+        run: bash ./script/build.sh
+        env:
+          TARGET_TRIPLE: x86_64-apple-darwin
+          OS_ARCH: darwin-amd64
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
+      - name: Build for Apple Silicon macOS
+        run: bash ./script/build.sh
+        env:
+          TARGET_TRIPLE: aarch64-apple-darwin
+          OS_ARCH: darwin-arm64
+      - name: Upload release artifact
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/darwin-amd64
+            dist/darwin-arm64
+  release-windows:
+    needs: release-linux
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build for x86_64 Windows
+        run: bash ./script/build.sh
+        env:
+          TARGET_TRIPLE: x86_64-pc-windows-msvc
+          OS_ARCH: windows-amd64.exe
+      - name: Upload release artifact
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/windows-amd64.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+/dist
+/gh-chk

--- a/README.md
+++ b/README.md
@@ -1,15 +1,33 @@
-# gh-chk
+# GitHub CLI Extension - gh chk
 
-A utility to check GitHub for my daily routine
+This extension allows you to interact with various GitHub features, such as pull requests, issues, contributions, notifications, and track assignees, all within your command line.
 
-## `gh-chk prs`
+## Installation
 
-Show all PRs on your organization
+```
+gh extension install yasuyuky/gh-chk
+```
 
-## `gh-chk contributions`
+## Usage
 
-Show your contributions
+```
+gh chk [OPTIONS] <COMMAND>
+```
 
-## `gh-chk notifications`
+## Commands
 
-Show your notifications
+- `prs` - Show pull requests of the repository or user.
+- `issues` - Show issues of the repository or user.
+- `contributions` - Show contributions of the user.
+- `notifications` - Show notifications of the user.
+- `track-assignees` - Track assignees of the issues or pull requests.
+- `login` - Login to GitHub.
+- `logout` - Logout from GitHub.
+- `help` - Print this message or the help of the given subcommand(s).
+
+## Options
+
+- `-f <FORMAT>` - Set output format. Default: `text`. Possible values: `text`, `json`.
+- `-h, --help` - Print help.
+
+For more usage information, you can run `gh-chk help <COMMAND>` to get details on how to use each command.

--- a/script/build.local.sh
+++ b/script/build.local.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+cargo build --release
+cp target/${TARGET_TRIPLE}/release/gh-chk .

--- a/script/build.sh
+++ b/script/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+mkdir -p ./dist
+
+TARGET_TRIPLE=${TARGET_TRIPLE:-x86_64-unknown-linux-gnu}
+OS_ARCH=${OS_ARCH:-linux-x64}
+
+cargo build --release --target ${TARGET_TRIPLE}
+cp target/${TARGET_TRIPLE}/release/gh-chk ./dist/${OS_ARCH}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,20 +18,20 @@ struct Opt {
 #[derive(Debug, Parser)]
 #[clap(rename_all = "kebab-case")]
 enum Command {
-    /// PRs
+    /// Show pullrequests of the repository or user
     Prs { slug: Vec<String> },
-    /// Issues
+    /// Show issues of the repository or user
     Issues { slug: Vec<String> },
-    /// Contriburions
+    /// Show contriburions of the user
     #[clap(alias = "grass")]
     Contributions { user: Option<String> },
-    /// Notifications
+    /// Show notifications of the user
     Notifications { page: usize },
-    /// TrackAssignees
+    /// Track assignees of the issues or pullrequests
     TrackAssignees { slug: String, num: usize },
-    /// Login
+    /// Login to GitHub
     Login,
-    /// Logout
+    /// Logout to GitHub
     Logout,
 }
 


### PR DESCRIPTION
- Add script to build and copy binary to target directory
- Create a build script that builds and copies gh-chk binary to dist directory
- Add entries for /dist and /gh-chk in .gitignore file
- Refactor command descriptions for clarity and specificity
- Improve the README
- Create release workflow that builds and uploads artifacts for Linux, macOS, and Windows
