### PR TITLE
Use token in gh config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,6 +728,7 @@ dependencies = [
  "read_input",
  "serde",
  "serde_json",
+ "serde_yaml",
  "surf",
  "time 0.3.23",
  "toml",
@@ -1388,6 +1389,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da6075b41c7e3b079e5f246eb6094a44850d3a4c25a67c581c80796c80134012"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,6 +1808,12 @@ dependencies = [
  "generic-array",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ read_input = "0.8.6"
 nestruct = "0.1.0"
 time = { version = "0.3.23", features = ["serde", "serde-well-known"] }
 clap = { version = "4.3.11", features = ["derive"] }
+serde_yaml = "0.9.23"
 
 [dependencies.async-std]
 features = ["attributes"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,7 +92,10 @@ pub static GH_CONFIG: Lazy<GHConfig> = Lazy::new(|| GHConfig::from_path(&GH_CONF
 
 pub static TOKEN: Lazy<String> = Lazy::new(|| match GH_CONFIG.entries.get("github.com") {
     Some(tok_conf) => tok_conf.oauth_token.clone(),
-    None => std::env::var("GITHUB_TOKEN").unwrap_or_default(),
+    None => match CONFIG.token.clone() {
+        Some(tok) => tok,
+        None => std::env::var("GITHUB_TOKEN").unwrap_or_default(),
+    },
 });
 
 pub static FORMAT: OnceLock<Format> = OnceLock::new();

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -43,6 +44,27 @@ pub struct TokenEntry {
     git_protocol: String,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+pub struct GHConfig {
+    #[serde(flatten)]
+    entries: HashMap<String, TokenEntry>,
+}
+
+impl GHConfig {
+    pub fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+        }
+    }
+
+    pub fn from_path(p: &Path) -> Self {
+        let mut s = String::new();
+        match File::open(p).and_then(|mut f| f.read_to_string(&mut s)) {
+            Ok(_) => serde_yaml::from_str(&s).unwrap_or_default(),
+            Err(_) => Self::new(),
+        }
+    }
+}
 
 pub static CONFIG_PATH: Lazy<PathBuf> = Lazy::new(|| {
     let mut path = match std::env::var("XDG_CONFIG_HOME") {

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,14 @@ impl Default for Config {
     }
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct TokenEntry {
+    user: String,
+    oauth_token: String,
+    git_protocol: String,
+}
+
+
 pub static CONFIG_PATH: Lazy<PathBuf> = Lazy::new(|| {
     let mut path = match std::env::var("XDG_CONFIG_HOME") {
         Ok(p) => PathBuf::from(p),

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,9 +78,21 @@ pub static CONFIG_PATH: Lazy<PathBuf> = Lazy::new(|| {
 
 pub static CONFIG: Lazy<Config> = Lazy::new(|| Config::from_path(&CONFIG_PATH));
 
-pub static TOKEN: Lazy<String> = Lazy::new(|| match std::env::var("GITHUB_TOKEN") {
-    Ok(tok) => tok,
-    Err(_) => CONFIG.token.clone().unwrap_or_default(),
+pub static GH_CONFIG_PATH: Lazy<PathBuf> = Lazy::new(|| {
+    let mut path = match std::env::var("XDG_CONFIG_HOME") {
+        Ok(p) => PathBuf::from(p),
+        Err(_) => PathBuf::from(std::env::var("HOME").unwrap() + "/.config"),
+    };
+    path.push("gh");
+    path.push("hosts.yml");
+    path
+});
+
+pub static GH_CONFIG: Lazy<GHConfig> = Lazy::new(|| GHConfig::from_path(&GH_CONFIG_PATH));
+
+pub static TOKEN: Lazy<String> = Lazy::new(|| match GH_CONFIG.entries.get("github.com") {
+    Some(tok_conf) => tok_conf.oauth_token.clone(),
+    None => std::env::var("GITHUB_TOKEN").unwrap_or_default(),
 });
 
 pub static FORMAT: OnceLock<Format> = OnceLock::new();


### PR DESCRIPTION
- Add serde_yaml
- Add TokenEntry struct to config.rs for storing user authentication information
- Add GHConfig struct to handle GitHub configurations from a file
- Refactor token retrieval to use GHConfig in config.rs
- Refactor TOKEN initialization in config.rs to use the value from CONFIG if available, otherwise fall back to the environment variable GITHUB_TOKEN
