### PR TITLE
Add Search

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -2,5 +2,6 @@ pub mod contributions;
 pub mod issues;
 pub mod notifications;
 pub mod prs;
+pub mod search;
 pub mod trackassignees;
 pub mod viewer;

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -1,0 +1,60 @@
+use crate::config::TOKEN;
+use colored::Colorize;
+
+nestruct::nest! {
+    #[derive(serde::Serialize, serde::Deserialize)]
+    Search {
+        total_count: usize,
+        incomplete_results: bool,
+        items: [{
+            name: String,
+            path: String,
+            sha: String,
+            url: String,
+            repository: {
+                full_name: String,
+                html_url: String,
+            }
+        }]
+    }
+
+}
+
+#[derive(serde::Serialize)]
+struct Query {
+    q: String,
+    page: usize,
+    per_page: u8,
+}
+
+pub async fn search(query: &str) -> surf::Result<()> {
+    let q = Query {
+        q: query.to_owned(),
+        page: 1,
+        per_page: 100,
+    };
+    let mut res = surf::get("https://api.github.com/search/code")
+        .header("Authorization", format!("token {}", *TOKEN))
+        .query(&q)?
+        .await?;
+    let search_result = res.body_json::<search::Search>().await?;
+    match crate::config::FORMAT.get() {
+        Some(&crate::config::Format::Json) => {
+            println!("{}", serde_json::to_string_pretty(&search_result)?)
+        }
+        _ => print_text(&search_result),
+    }
+    Ok(())
+}
+
+fn print_text(res: &search::Search) {
+    for n in &res.items {
+        println!(
+            "{} {} {}",
+            n.repository.full_name.cyan(),
+            n.path.yellow(),
+            n.url.green(),
+        )
+    }
+    println!("# count: {}", res.items.len());
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,8 @@ enum Command {
     Notifications { page: usize },
     /// Track assignees of the issues or pullrequests
     TrackAssignees { slug: String, num: usize },
+    /// Search repositories
+    Search { query: String },
     /// Login to GitHub
     Login,
     /// Logout to GitHub
@@ -68,6 +70,7 @@ async fn main() -> surf::Result<()> {
         Command::Contributions { user } => cmd::contributions::check(user).await?,
         Command::Notifications { page } => cmd::notifications::list(page).await?,
         Command::TrackAssignees { slug, num } => cmd::trackassignees::track(&slug, num).await?,
+        Command::Search { query } => cmd::search::search(&query).await?,
         Command::Login => login()?,
         Command::Logout => logout()?,
     };


### PR DESCRIPTION
- Add search functionality to the command line tool, which sends a request to the GitHub API and prints the search results in a formatted way
- Add search functionality to the application
