### PR TITLE
Add feature to mark notifications as read

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,11 @@ enum Command {
     #[clap(alias = "grass")]
     Contributions { user: Option<String> },
     /// Show notifications of the user
-    Notifications { page: usize },
+    Notifications {
+        page: usize,
+        #[clap(long = "read")]
+        read: bool,
+    },
     /// Track assignees of the issues or pullrequests
     TrackAssignees { slug: String, num: usize },
     /// Search repositories
@@ -68,7 +72,7 @@ async fn main() -> surf::Result<()> {
         Command::Prs { slug } => cmd::prs::check(slug).await?,
         Command::Issues { slug } => cmd::issues::check(slug).await?,
         Command::Contributions { user } => cmd::contributions::check(user).await?,
-        Command::Notifications { page } => cmd::notifications::list(page).await?,
+        Command::Notifications { page, read } => cmd::notifications::list(page, read).await?,
         Command::TrackAssignees { slug, num } => cmd::trackassignees::track(&slug, num).await?,
         Command::Search(q) => cmd::search::search(&q).await?,
         Command::Login => login()?,

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -40,3 +40,10 @@ pub async fn get_page(url: &str, page: usize) -> surf::Result<surf::Response> {
         .query(&q)?
         .await
 }
+
+pub async fn patch(path: &str) -> surf::Result<surf::Response> {
+    let uri = BASE_URI.to_owned() + path;
+    surf::patch(uri)
+        .header("Authorization", format!("token {}", *TOKEN))
+        .await
+}


### PR DESCRIPTION
- Add a function to perform a PATCH request with authorization headers
- Refactor notifications.rs to include the ability to mark notifications as read when printing text
- Refactor Notifications command to include a "read" flag for listing notifications
