### PR TITLE
Update rust-version to 1.74.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["yasuyuky <yasuyuki.ymd@gmail.com>"]
 edition = "2018"
 name = "gh-chk"
 version = "0.2.0"
-rust-version = "1.74.0"
+rust-version = "1.74.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]


### PR DESCRIPTION
This pull request updates the rust-version in the Cargo.toml file to 1.74.1.