### PR TITLE
Update Rust version to 1.76.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["yasuyuky <yasuyuki.ymd@gmail.com>"]
 edition = "2018"
 name = "gh-chk"
 version = "0.3.0"
-rust-version = "1.75.0"
+rust-version = "1.76.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]


### PR DESCRIPTION
This pull request updates the Rust version to 1.76.0.