### PR TITLE
Update default Config implementation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -33,7 +33,7 @@ impl Config {
 
 impl Default for Config {
     fn default() -> Self {
-        Self::new()
+        Self { token: None }
     }
 }
 


### PR DESCRIPTION
The default() function in the Default trait is used to create a default instance of the type. While implementing this, if a function call returns the same type, it could possibly create an infinite loop by calling default() itself.