### PR TITLE
Update dependabot schedules for cargo and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,14 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
       time: "09:00"
       timezone: Asia/Tokyo
+      day:
+        - monday
+        - tuesday
+        - wednesday
+        - thursday
+        - friday
+        - saturday
+        - sunday

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,17 @@ updates:
   - package-ecosystem: cargo
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
       time: "09:00"
       timezone: Asia/Tokyo
+      day:
+        - monday
+        - tuesday
+        - wednesday
+        - thursday
+        - friday
+        - saturday
+        - sunday
     open-pull-requests-limit: 10
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
This pull request updates the dependabot schedules for the cargo and github-actions package ecosystems to run weekly instead of daily. This change ensures that the dependency updates are checked less frequently, reducing unnecessary notifications and potential disruptions. The schedules are now set to run every day of the week at 09:00 in the Asia/Tokyo timezone. This aligns with the desired frequency and timing for dependency updates.