### PR TITLE
Revise notifications handling and output format

### DIFF
--- a/src/cmd/notifications.rs
+++ b/src/cmd/notifications.rs
@@ -22,7 +22,15 @@ nestruct::nest! {
 }
 
 pub async fn list(page: usize, read: bool) -> surf::Result<()> {
-    let res = crate::rest::get::<notification::Notification>("notifications", page).await?;
+    let mut res = Vec::new();
+    let mut page = 1;
+    while let Ok(mut page_res) = list_page(page).await {
+        if page_res.is_empty() {
+            break;
+        }
+        res.append(&mut page_res);
+        page += 1;
+    }
     match crate::config::FORMAT.get() {
         Some(&crate::config::Format::Json) => println!("{}", serde_json::to_string_pretty(&res)?),
         _ => print_text(&res, read).await,

--- a/src/cmd/notifications.rs
+++ b/src/cmd/notifications.rs
@@ -21,7 +21,7 @@ nestruct::nest! {
     }
 }
 
-pub async fn list(page: usize, read: bool) -> surf::Result<()> {
+pub async fn list(read: bool) -> surf::Result<()> {
     let mut res = Vec::new();
     let mut page = 1;
     while let Ok(mut page_res) = list_page(page).await {

--- a/src/cmd/notifications.rs
+++ b/src/cmd/notifications.rs
@@ -30,6 +30,11 @@ pub async fn list(page: usize, read: bool) -> surf::Result<()> {
     Ok(())
 }
 
+pub async fn list_page(page: usize) -> surf::Result<Vec<notification::Notification>> {
+    let res = crate::rest::get::<notification::Notification>("notifications", page).await?;
+    Ok(res)
+}
+
 async fn print_text(res: &[notification::Notification], read: bool) {
     for n in res {
         let status = match &n.subject.url {

--- a/src/cmd/notifications.rs
+++ b/src/cmd/notifications.rs
@@ -37,7 +37,7 @@ async fn print_text(res: &[notification::Notification], read: bool) {
             None => String::default(),
         };
         println!(
-            "{:10} {:10} {:11} {:6} {} {} {} {}",
+            "{:10} {:12} {:11} {:6} {} {} {} {}",
             n.id.black(),
             n.reason.magenta(),
             n.subject.ntype.yellow(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,6 @@ enum Command {
     Contributions { user: Option<String> },
     /// Show notifications of the user
     Notifications {
-        page: usize,
         #[clap(long = "read")]
         read: bool,
     },
@@ -72,7 +71,7 @@ async fn main() -> surf::Result<()> {
         Command::Prs { slug } => cmd::prs::check(slug).await?,
         Command::Issues { slug } => cmd::issues::check(slug).await?,
         Command::Contributions { user } => cmd::contributions::check(user).await?,
-        Command::Notifications { page, read } => cmd::notifications::list(page, read).await?,
+        Command::Notifications { read } => cmd::notifications::list(read).await?,
         Command::TrackAssignees { slug, num } => cmd::trackassignees::track(&slug, num).await?,
         Command::Search(q) => cmd::search::search(&q).await?,
         Command::Login => login()?,


### PR DESCRIPTION
Refactor the notifications list function to implement pagination and revise the output format of notifications. Remove the pagination parameter from the command interface for a cleaner API.