### PR TITLE
Refactor REST API query handling with HashMap support

### DIFF
--- a/src/cmd/notifications.rs
+++ b/src/cmd/notifications.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -39,7 +41,8 @@ pub async fn list(read: bool) -> surf::Result<()> {
 }
 
 pub async fn list_page(page: usize) -> surf::Result<Vec<notification::Notification>> {
-    let res = crate::rest::get::<notification::Notification>("notifications", page).await?;
+    let q = HashMap::new();
+    let res = crate::rest::get::<notification::Notification>("notifications", page, &q).await?;
     Ok(res)
 }
 

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -30,12 +30,6 @@ pub async fn get<T: DeserializeOwned>(
     res.body_json().await
 }
 
-#[derive(Serialize)]
-struct Query {
-    page: usize,
-    per_page: u8,
-}
-
 pub async fn get_page(url: &str, page: usize, q: &QueryMap) -> surf::Result<surf::Response> {
     let mut query = HashMap::new();
     query.insert("page", page.to_string());

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -33,7 +33,7 @@ pub async fn get_page(url: &str, page: usize, q: &QueryMap) -> surf::Result<surf
     let mut query = HashMap::new();
     query.insert("page", page.to_string());
     query.insert("per_page", 100.to_string());
-    query.extend(q.iter().map(|(k, v)| (k.as_str(), v.clone())));
+    query.extend(q.iter().map(|(k, v)| (k.as_str(), v.clone()))); // skipcq: RS-A1009
     surf::get(url)
         .header("Authorization", format!("token {}", *TOKEN))
         .query(&query)?

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use surf::http::convert::Serialize;
 
 const BASE_URI: &str = "https://api.github.com/";
+pub type QueryMap = HashMap<String, String>;
 
 #[allow(dead_code)]
 fn parse_next(res: &surf::Response) -> Option<String> {
@@ -19,9 +20,13 @@ fn parse_next(res: &surf::Response) -> Option<String> {
     None
 }
 
-pub async fn get<T: DeserializeOwned>(path: &str, page: usize) -> surf::Result<Vec<T>> {
+pub async fn get<T: DeserializeOwned>(
+    path: &str,
+    page: usize,
+    q: &QueryMap,
+) -> surf::Result<Vec<T>> {
     let uri = BASE_URI.to_owned() + path;
-    let mut res = get_page(&uri, page).await?;
+    let mut res = get_page(&uri, page, q).await?;
     res.body_json().await
 }
 
@@ -31,7 +36,7 @@ struct Query {
     per_page: u8,
 }
 
-pub async fn get_page(url: &str, page: usize) -> surf::Result<surf::Response> {
+pub async fn get_page(url: &str, page: usize, q: &QueryMap) -> surf::Result<surf::Response> {
     let mut query = HashMap::new();
     query.insert("page", page.to_string());
     query.insert("per_page", 100.to_string());

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1,5 +1,6 @@
 use crate::config::TOKEN;
 use serde::de::DeserializeOwned;
+use std::collections::HashMap;
 use surf::http::convert::Serialize;
 
 const BASE_URI: &str = "https://api.github.com/";

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -40,6 +40,7 @@ pub async fn get_page(url: &str, page: usize, q: &QueryMap) -> surf::Result<surf
     let mut query = HashMap::new();
     query.insert("page", page.to_string());
     query.insert("per_page", 100.to_string());
+    query.extend(q.iter().map(|(k, v)| (k.as_str(), v.clone())));
     surf::get(url)
         .header("Authorization", format!("token {}", *TOKEN))
         .query(&query)?

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -31,13 +31,12 @@ struct Query {
 }
 
 pub async fn get_page(url: &str, page: usize) -> surf::Result<surf::Response> {
-    let q = Query {
-        page,
-        per_page: 100,
-    };
+    let mut query = HashMap::new();
+    query.insert("page", page.to_string());
+    query.insert("per_page", 100.to_string());
     surf::get(url)
         .header("Authorization", format!("token {}", *TOKEN))
-        .query(&q)?
+        .query(&query)?
         .await
 }
 

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1,7 +1,6 @@
 use crate::config::TOKEN;
 use serde::de::DeserializeOwned;
 use std::collections::HashMap;
-use surf::http::convert::Serialize;
 
 const BASE_URI: &str = "https://api.github.com/";
 pub type QueryMap = HashMap<String, String>;


### PR DESCRIPTION
Refactor the query construction in the `get_page` function to utilize a `HashMap`, enabling support for additional query parameters in REST API calls. Remove unused structures and imports to streamline the code.