### PR TITLE
Update GitHub Actions workflow to use Rust container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,10 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container: rust:latest
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          components: rustfmt, clippy
       - name: Build
         run: cargo build --verbose
       - name: Run tests


### PR DESCRIPTION
Replace the toolchain setup with a Rust container in the GitHub Actions workflow for a more streamlined build process.