### PR TITLE
Update Rust edition to 2024 in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["yasuyuky <yasuyuki.ymd@gmail.com>"]
-edition = "2018"
+edition = "2021"
 name = "gh-chk"
 version = "0.3.0"
 rust-version = "1.85.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["yasuyuky <yasuyuki.ymd@gmail.com>"]
-edition = "2021"
+edition = "2024"
 name = "gh-chk"
 version = "0.3.0"
 rust-version = "1.85.0"


### PR DESCRIPTION
Upgrade the Rust edition in the Cargo.toml file from 2018 to 2024 to ensure compatibility with the latest features and improvements.