### PR TITLE
Specify lifetime for Text in make_diff_text and update UI preview display logic

### DIFF
--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -503,7 +503,7 @@ fn contrast_fg(r: u8, g: u8, b: u8) -> Color {
     }
 }
 
-fn make_diff_text(diff: &str) -> Text {
+fn make_diff_text(diff: &str) -> Text<'_> {
     let mut text = Text::default();
     for line in diff.lines() {
         let styled = if line.starts_with("===") {

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -658,11 +658,15 @@ fn ui(f: &mut Frame, app: &mut App) {
         } else {
             "↑/↓:navigate"
         };
-        let mode = match app.preview_mode {
-            PreviewMode::Body => "Body",
-            PreviewMode::Diff => "Diff",
-        };
-        format!("{} • {} • mode:{}", base, nav, mode)
+        if app.preview_open {
+            let mode = match app.preview_mode {
+                PreviewMode::Body => "Body",
+                PreviewMode::Diff => "Diff",
+            };
+            format!("{} • {} • mode:{}", base, nav, mode)
+        } else {
+            format!("{} • {}", base, nav)
+        }
     };
 
     let help = Paragraph::new(help_text)


### PR DESCRIPTION
Define a lifetime for the `Text` type in the `make_diff_text` function and modify the UI to conditionally display the preview mode based on the preview state.