### PR TITLE
Add reviewDecision field to pull requests

### DIFF
--- a/src/cmd/prs.rs
+++ b/src/cmd/prs.rs
@@ -32,6 +32,7 @@ nestruct::nest! {
                 url: String,
                 created_at: String,
                 merge_state_status: crate::cmd::prs::MergeStateStatus,
+                review_decision: Option<crate::cmd::prs::ReviewDecision>,
                 review_requests: {
                     nodes: [{
                         requested_reviewer: Option<crate::cmd::prs::RequestedReviewer>,
@@ -76,12 +77,23 @@ impl Display for repository::pull_requests::nodes::Nodes {
             .next()
             .unwrap_or(&self.created_at)
             .to_string();
+        let review = match &self.review_decision {
+            Some(rd) => {
+                let label = rd.to_label();
+                let bracketed = format!("[{}]", label);
+                rd.colorize(&bracketed)
+            }
+            None => String::new(),
+        };
+        let review_sep = if review.is_empty() { "" } else { " " };
         let s = format!(
-            "{:>6} {} {} {} {}",
+            "{:>6} {} {} {}{}{} {}",
             format!("#{}", self.number).bold(),
             self.merge_state_status.to_emoji(),
             self.url,
             self.title.bold(),
+            review_sep,
+            review,
             format!("({})", created_date).bright_black()
         );
         write!(f, "{}", self.merge_state_status.colorize(&s))
@@ -127,6 +139,34 @@ impl MergeStateStatus {
             Self::HasHooks => s.yellow(),
             Self::Unknown => s.magenta(),
             Self::Unstable => s.yellow(),
+        }
+        .to_string()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ReviewDecision {
+    Approved,
+    ChangesRequested,
+    ReviewRequired,
+}
+
+impl ReviewDecision {
+    fn to_label(&self) -> &'static str {
+        match self {
+            Self::Approved => "approved",
+            Self::ChangesRequested => "changes requested",
+            Self::ReviewRequired => "review required",
+        }
+    }
+
+    fn colorize(&self, s: &str) -> String {
+        use colored::Colorize as _;
+        match self {
+            Self::Approved => s.green(),
+            Self::ChangesRequested => s.red(),
+            Self::ReviewRequired => s.yellow(),
         }
         .to_string()
     }

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -1,4 +1,4 @@
-use crate::cmd::prs::MergeStateStatus;
+use crate::cmd::prs::{MergeStateStatus, ReviewDecision};
 use crate::{graphql, rest};
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, MouseEventKind},
@@ -79,11 +79,18 @@ struct PrData {
     pub created_at: String,
     pub slug: String,
     pub merge_state_status: MergeStateStatus,
+    pub review_decision: Option<ReviewDecision>,
     pub reviewers: Vec<String>,
 }
 
 impl PrData {
     pub fn display_line(&self) -> String {
+        let review_str = match &self.review_decision {
+            Some(ReviewDecision::Approved) => " [approved]".to_string(),
+            Some(ReviewDecision::ChangesRequested) => " [changes requested]".to_string(),
+            Some(ReviewDecision::ReviewRequired) => " [review required]".to_string(),
+            None => String::new(),
+        };
         let reviewers_str = if self.reviewers.is_empty() {
             String::default()
         } else {
@@ -96,11 +103,12 @@ impl PrData {
             .unwrap_or(&self.created_at)
             .to_string();
         format!(
-            "{} {} {} {}{} ({})",
+            "{} {} {} {}{}{} ({})",
             format!("#{}", self.number),
             self.merge_state_status.to_emoji(),
             self.slug,
             self.title,
+            review_str,
             reviewers_str,
             created_date
         )
@@ -125,6 +133,7 @@ fn make_pr_data(owner: &str, repo: &str, pr: &PrNode) -> PrData {
         created_at: pr.created_at.clone(),
         slug: format!("{}/{}", owner, repo),
         merge_state_status: pr.merge_state_status.clone(),
+        review_decision: pr.review_decision.clone(),
         reviewers: extract_reviewer_names(&pr.review_requests),
     }
 }

--- a/src/query/prs.graphql
+++ b/src/query/prs.graphql
@@ -11,6 +11,7 @@ query ($login: String!) {
             url
             createdAt
             mergeStateStatus
+            reviewDecision
             reviewRequests(first: 10) {
               nodes {
                 requestedReviewer {

--- a/src/query/prs.repo.graphql
+++ b/src/query/prs.repo.graphql
@@ -10,6 +10,7 @@ query ($login: String!, $name: String!) {
           url
           createdAt
           mergeStateStatus
+          reviewDecision
           reviewRequests(first: 10) {
             nodes {
               requestedReviewer {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -16,6 +16,13 @@ fn run_cmd(args: &[&str], data: &str) -> String {
 fn prs_output() {
     let out = run_cmd(&["-f", "json", "prs", "foo"], "prs.json");
     assert!(out.contains("\"mergeStateStatus\": \"CLEAN\""));
+    assert!(out.contains("\"reviewDecision\": \"APPROVED\""));
+}
+
+#[test]
+fn prs_text_includes_review_status() {
+    let out = run_cmd(&["-f", "text", "prs", "foo"], "prs.json");
+    assert!(out.contains("[approved]"));
 }
 
 #[test]

--- a/tests/data/prs.json
+++ b/tests/data/prs.json
@@ -14,6 +14,7 @@
                   "url": "http://example.com/pr1",
                   "createdAt": "2024-08-01T12:34:56Z",
                   "mergeStateStatus": "CLEAN",
+                  "reviewDecision": "APPROVED",
                   "reviewRequests": {
                     "nodes": []
                   }


### PR DESCRIPTION
Introduce a new reviewDecision field in pull request queries and display logic, enhancing the representation of review statuses in the application. Update tests to validate the inclusion of reviewDecision in outputs.