### PR TITLE
Update approval status message to indicate reloading after approval

### DIFF
--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -317,7 +317,11 @@ impl App {
             self.set_status_persistent(format!("Approving PR #{} in {}...", pr.number, pr.slug));
             match approve_pr(&pr.id).await {
                 Ok(_) => {
-                    self.set_status(format!("✅ Approved PR #{} in {}", pr.number, pr.slug));
+                    self.set_status_persistent(format!(
+                        "✅ Approved PR #{} in {}. Reloading...",
+                        pr.number, pr.slug
+                    ));
+                    self.pending_task = Some(PendingTask::Reload);
                 }
                 Err(e) => {
                     self.set_status(format!(


### PR DESCRIPTION
Modify the approval status message to inform users that a reload will occur after approving a pull request.