### PR TITLE
Update schema URL to correct GitHub documentation link

### DIFF
--- a/.graphqlrc.yaml
+++ b/.graphqlrc.yaml
@@ -1,2 +1,2 @@
-schema: schema.docs.graphql
+schema: "https://docs.github.com/public/fpt/schema.docs.graphql"
 documents: "src/**/*.graphql"


### PR DESCRIPTION
Replace the schema URL with the correct link to the GitHub documentation.