### PR TITLE
Add repository owner's login to PR queries and responses

### DIFF
--- a/src/cmd/prs.rs
+++ b/src/cmd/prs.rs
@@ -49,6 +49,7 @@ nestruct::nest! {
     Res {
         data: {
             repository_owner: {
+                login: String,
                 repositories: {
                     nodes: [ crate::cmd::prs::repository::Repository ]
                 }
@@ -63,6 +64,7 @@ nestruct::nest! {
     RepoRes {
         data: {
             repository_owner: {
+                login: String,
                 repository: crate::cmd::prs::repository::Repository
             }
         }

--- a/src/query/prs.graphql
+++ b/src/query/prs.graphql
@@ -1,5 +1,6 @@
 query ($login: String!) {
   repositoryOwner(login: $login) {
+    login
     repositories(first: 100, affiliations: OWNER) {
       nodes {
         name

--- a/src/query/prs.repo.graphql
+++ b/src/query/prs.repo.graphql
@@ -1,5 +1,6 @@
 query ($login: String!, $name: String!) {
   repositoryOwner(login: $login) {
+    login
     repository(name: $name) {
       name
       pullRequests(first: 100, states: OPEN) {

--- a/tests/data/prs.json
+++ b/tests/data/prs.json
@@ -1,6 +1,7 @@
 {
   "data": {
     "repositoryOwner": {
+      "login": "owner1",
       "repositories": {
         "nodes": [
           {


### PR DESCRIPTION
Enhance the pull request queries and response structures to include the repository owner's login information. This improves the context and usability of the data returned.