### PR TITLE
Refactor contribution date handling to reuse calendar-based logic

### DIFF
--- a/src/cmd/contributions.rs
+++ b/src/cmd/contributions.rs
@@ -30,12 +30,27 @@ pub mod model {
     pub use super::res::*;
 }
 
+pub struct CalendarDates<'a> {
+    pub today: &'a str,
+    pub week_start: &'a str,
+}
+
 // Fetch raw contribution calendar result for a given login
 pub async fn fetch_calendar(login: &str) -> surf::Result<model::Res> {
     let var = json!({ "login": login });
     let q = json!({ "query": include_str!("../query/contributions.graphql"), "variables": var });
     let res = crate::graphql::query::<model::Res>(&q).await?;
     Ok(res)
+}
+
+pub fn calendar_dates(res: &model::Res) -> CalendarDates<'_> {
+    let calendar = &res.data.user.contributions_collection.contribution_calendar;
+    let this_week = calendar.weeks.last().unwrap();
+    let today = this_week.contribution_days.last().unwrap();
+    CalendarDates {
+        today: today.date.as_str(),
+        week_start: this_week.first_day.as_str(),
+    }
 }
 
 pub async fn check(user: Option<String>) -> surf::Result<()> {
@@ -51,10 +66,9 @@ pub async fn check(user: Option<String>) -> surf::Result<()> {
 fn print_text(res: &res::Res) -> surf::Result<()> {
     let calendar = &res.data.user.contributions_collection.contribution_calendar;
     let (mut year_to_date, mut month_to_date) = ((0, 0), (0, 0));
-    let this_week = calendar.weeks.last().unwrap();
-    let today = this_week.contribution_days.last().unwrap().date.clone();
-    let today_year = today.chars().take(4).collect::<String>();
-    let today_month = today.chars().take(7).collect::<String>();
+    let dates = calendar_dates(res);
+    let today_year = dates.today.chars().take(4).collect::<String>();
+    let today_month = dates.today.chars().take(7).collect::<String>();
 
     for week in &calendar.weeks {
         print!("{}: ", week.first_day);
@@ -85,4 +99,38 @@ fn print_text(res: &res::Res) -> surf::Result<()> {
     println!("# year to date:        {:4} {:>5.2}", year_to_date.0, yavg);
     println!("# month to date:       {:4} {:>5.2}", month_to_date.0, mavg);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn calendar_dates_use_last_contribution_day() {
+        let res = serde_json::from_value(json!({
+            "data": {
+                "user": {
+                    "contributionsCollection": {
+                        "contributionCalendar": {
+                            "totalContributions": 3,
+                            "weeks": [{
+                                "firstDay": "2026-05-10",
+                                "contributionDays": [{
+                                    "color": "#40c463",
+                                    "contributionCount": 3,
+                                    "date": "2026-05-10"
+                                }]
+                            }]
+                        }
+                    }
+                }
+            }
+        }))
+        .expect("deserialize contribution calendar");
+
+        let dates = calendar_dates(&res);
+
+        assert_eq!(dates.today, "2026-05-10");
+        assert_eq!(dates.week_start, "2026-05-10");
+    }
 }

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -20,7 +20,6 @@ use std::io::{self, Write};
 use std::process::{Command, Stdio};
 use std::rc::Rc;
 use std::time::{Duration, Instant};
-use time::OffsetDateTime;
 
 // Type alias for GraphQL PR node for brevity (reuse prs module types)
 type PrNode = prs::pull_request::PullRequest;
@@ -490,9 +489,8 @@ impl App {
         let weeks = &cal.weeks;
         let mut lines: Vec<Line> = Vec::new();
         self.contrib_title = format!("Contributions: total {}", cal.total_contributions);
-        // Use the current date to avoid padded future days skewing YTD/MTD.
-        let today_date = OffsetDateTime::now_utc().date();
-        let window = ContribWindow::new(today_date);
+        let dates = crate::cmd::contributions::calendar_dates(&res);
+        let window = ContribWindow::new(dates.today, dates.week_start);
         let mut year_to_date = ContribTotals::default();
         let mut month_to_date = ContribTotals::default();
         let mut week_to_date = ContribTotals::default();
@@ -566,17 +564,14 @@ struct ContribWindow {
 }
 
 impl ContribWindow {
-    fn new(today_date: time::Date) -> Self {
-        let today = today_date.to_string();
+    fn new(today: &str, week_start: &str) -> Self {
         let today_year = today[..4].to_string();
         let today_month = today[..7].to_string();
-        let days_from_sunday = today_date.weekday().number_from_sunday() - 1;
-        let week_start = (today_date - time::Duration::days(days_from_sunday as i64)).to_string();
         Self {
-            today,
+            today: today.to_string(),
             today_year,
             today_month,
-            week_start,
+            week_start: week_start.to_string(),
         }
     }
 
@@ -1535,6 +1530,20 @@ mod tests {
     #[test]
     fn search_results_help_mentions_copy_slug() {
         assert!(search_help_base(SearchFocus::Results).contains("c:copy slug"));
+    }
+
+    #[test]
+    fn contrib_window_includes_calendar_today() {
+        let window = ContribWindow::new("2026-05-10", "2026-05-10");
+        let mut year = ContribTotals::default();
+        let mut month = ContribTotals::default();
+        let mut week = ContribTotals::default();
+
+        window.update_totals("2026-05-10", 3, &mut year, &mut month, &mut week);
+
+        assert_eq!(year.total, 3);
+        assert_eq!(month.total, 3);
+        assert_eq!(week.total, 3);
     }
 
     #[async_std::test]


### PR DESCRIPTION
**Summary**
- Reuse the GitHub contribution calendar’s last visible day as the reference date in both CLI and TUI.
- Remove the TUI’s UTC-now based cutoff so early-morning local runs no longer drop the current day.
- Keep the contribution window logic shared and aligned between the two render paths.

**Testing**
- Added unit coverage for the shared calendar date helper.
- Added a TUI-level unit test to confirm the current calendar day is included in YTD/MTD/WTD totals.
- `cargo test --locked` passed.