### PR TITLE
Bump Rust MSRV to 1.96.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["yasuyuky <yasuyuki.ymd@gmail.com>"]
 edition = "2024"
 name = "gh-chk"
 version = "0.3.0"
-rust-version = "1.95.0"
+rust-version = "1.96.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]


### PR DESCRIPTION
## Summary
- Update `Cargo.toml` to require Rust `1.96.0`
- Keep the change limited to the crate MSRV bump

## Testing
- `cargo test --locked` passed locally