### PR TITLE
Add a TUI shortcut to open the viewer profile in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,5 @@ Basic keys:
 - `q` - Quit.
 - Arrow keys or `j`/`k` - Move selection.
 - `Enter` or `o` - Open the selected pull request in browser.
+- `p` - Open your GitHub profile in browser.
 - `s` - Search code. In the search input, use `Up`/`Down` to browse search history.

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -1659,6 +1659,16 @@ mod tests {
     }
 
     #[test]
+    fn prs_help_mentions_profile_shortcut() {
+        assert!(prs_help_base().contains("p:profile"));
+    }
+
+    #[test]
+    fn profile_url_uses_viewer_login() {
+        assert_eq!(profile_url("octocat"), "https://github.com/octocat");
+    }
+
+    #[test]
     fn search_history_keeps_latest_unique_queries() {
         let mut history = Vec::new();
         assert!(push_search_history(&mut history, " first "));

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -289,6 +289,7 @@ struct App {
     contrib_stats: Option<Vec<Line<'static>>>,
     contrib_height: u16,
     contrib_title: String,
+    viewer_login: Option<String>,
     pending_task: Option<PendingTask>,
     mode: AppMode,
     search: SearchState,
@@ -316,6 +317,7 @@ impl App {
             contrib_stats: None,
             contrib_height: 9,
             contrib_title: "Contributions".to_string(),
+            viewer_login: None,
             pending_task: None,
             mode: AppMode::Prs,
             search: SearchState::new(search_owner, search_history),
@@ -580,6 +582,7 @@ impl App {
 
     async fn load_contributions(&mut self) -> surf::Result<()> {
         let login = crate::cmd::viewer::get().await?;
+        self.viewer_login = Some(login.clone());
         let res = crate::cmd::contributions::fetch_calendar(&login).await?;
         let cal = &res.data.user.contributions_collection.contribution_calendar;
         let weeks = &cal.weeks;
@@ -1733,6 +1736,7 @@ mod tests {
             contrib_stats: None,
             contrib_height: 9,
             contrib_title: "Contributions".to_string(),
+            viewer_login: None,
             pending_task: None,
             mode: AppMode::Search,
             search: SearchState {

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -1260,6 +1260,7 @@ impl App {
             KeyCode::Down | KeyCode::Char('j') => self.on_down().await,
             KeyCode::Up | KeyCode::Char('k') => self.on_up().await,
             KeyCode::Enter | KeyCode::Char('o') => self.on_open(),
+            KeyCode::Char('p') => self.on_open_profile(),
             KeyCode::Char('m') => self.on_merge_key(),
             KeyCode::Char('a') => self.on_approve_key(),
             KeyCode::Char('r') => self.on_reload_key(),

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -1024,7 +1024,7 @@ fn build_help_text(app: &App) -> String {
     } else {
         match app.mode {
             AppMode::Prs => {
-                let base = "q:quit • s:search • ?:help • Enter/o:open • m:merge • a:approve • r:reload PR • R:reload all • c:reload contrib • ←/→:list/body/diff/graph";
+                let base = prs_help_base();
                 let nav = if app.preview.mode.is_some() {
                     "↑/↓/wheel:scroll"
                 } else {
@@ -1046,6 +1046,10 @@ fn build_help_text(app: &App) -> String {
             }
         }
     }
+}
+
+fn prs_help_base() -> &'static str {
+    "q:quit • s:search • ?:help • Enter/o:open • p:profile • m:merge • a:approve • r:reload PR • R:reload all • c:reload contrib • ←/→:list/body/diff/graph"
 }
 
 fn search_help_base(focus: SearchFocus) -> &'static str {

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -226,6 +226,10 @@ fn is_search_back_key(focus: SearchFocus, code: KeyCode) -> bool {
     )
 }
 
+fn profile_url(login: &str) -> String {
+    format!("https://github.com/{login}")
+}
+
 #[cfg(target_os = "macos")]
 const CLIPBOARD_COMMANDS: &[(&str, &[&str])] = &[("pbcopy", &[])];
 

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -226,10 +226,6 @@ fn is_search_back_key(focus: SearchFocus, code: KeyCode) -> bool {
     )
 }
 
-fn profile_url(login: &str) -> String {
-    format!("https://github.com/{login}")
-}
-
 #[cfg(target_os = "macos")]
 const CLIPBOARD_COMMANDS: &[(&str, &[&str])] = &[("pbcopy", &[])];
 
@@ -289,7 +285,7 @@ struct App {
     contrib_stats: Option<Vec<Line<'static>>>,
     contrib_height: u16,
     contrib_title: String,
-    viewer_login: Option<String>,
+    viewer_profile_url: Option<String>,
     pending_task: Option<PendingTask>,
     mode: AppMode,
     search: SearchState,
@@ -317,7 +313,7 @@ impl App {
             contrib_stats: None,
             contrib_height: 9,
             contrib_title: "Contributions".to_string(),
-            viewer_login: None,
+            viewer_profile_url: None,
             pending_task: None,
             mode: AppMode::Prs,
             search: SearchState::new(search_owner, search_history),
@@ -581,9 +577,9 @@ impl App {
     }
 
     async fn load_contributions(&mut self) -> surf::Result<()> {
-        let login = crate::cmd::viewer::get().await?;
-        self.viewer_login = Some(login.clone());
-        let res = crate::cmd::contributions::fetch_calendar(&login).await?;
+        let profile = crate::cmd::viewer::get_profile().await?;
+        self.viewer_profile_url = Some(profile.url);
+        let res = crate::cmd::contributions::fetch_calendar(&profile.login).await?;
         let cal = &res.data.user.contributions_collection.contribution_calendar;
         let weeks = &cal.weeks;
         let mut lines: Vec<Line> = Vec::new();
@@ -1344,12 +1340,12 @@ impl App {
     }
 
     fn on_open_profile(&mut self) {
-        let Some(login) = self.viewer_login.clone() else {
+        let Some(url) = self.viewer_profile_url.as_deref() else {
             self.set_status("No viewer profile loaded.");
             return;
         };
-        if let Err(e) = open::that(profile_url(&login)) {
-            self.set_status(format!("❌ Failed to open profile for {}: {}", login, e));
+        if let Err(e) = open::that(url) {
+            self.set_status(format!("❌ Failed to open profile: {}", e));
         }
     }
 
@@ -1664,11 +1660,6 @@ mod tests {
     }
 
     #[test]
-    fn profile_url_uses_viewer_login() {
-        assert_eq!(profile_url("octocat"), "https://github.com/octocat");
-    }
-
-    #[test]
     fn search_history_keeps_latest_unique_queries() {
         let mut history = Vec::new();
         assert!(push_search_history(&mut history, " first "));
@@ -1751,7 +1742,7 @@ mod tests {
             contrib_stats: None,
             contrib_height: 9,
             contrib_title: "Contributions".to_string(),
-            viewer_login: None,
+            viewer_profile_url: None,
             pending_task: None,
             mode: AppMode::Search,
             search: SearchState {

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -1331,6 +1331,16 @@ impl App {
         self.open_url();
     }
 
+    fn on_open_profile(&mut self) {
+        let Some(login) = self.viewer_login.clone() else {
+            self.set_status("No viewer profile loaded.");
+            return;
+        };
+        if let Err(e) = open::that(profile_url(&login)) {
+            self.set_status(format!("❌ Failed to open profile for {}: {}", login, e));
+        }
+    }
+
     fn open_search_result(&mut self) {
         let Some(item) = self.selected_search_result() else {
             return;

--- a/src/cmd/viewer.rs
+++ b/src/cmd/viewer.rs
@@ -1,18 +1,47 @@
 use serde_json::json;
 
+pub struct Profile {
+    pub login: String,
+    pub url: String,
+}
+
 nestruct::nest! {
     #[derive(serde::Deserialize, serde::Serialize)]
     Res {
         data: {
             viewer: {
-                login: String
+                login: String,
+                url: String
             }
         }
     }
 }
 
-pub async fn get() -> surf::Result<String> {
+pub async fn get_profile() -> surf::Result<Profile> {
     let q = json!({ "query": include_str!("../query/viewer.graphql") });
     let res = crate::graphql::query::<res::Res>(&q).await?;
-    Ok(res.data.viewer.login)
+    Ok(Profile {
+        login: res.data.viewer.login,
+        url: res.data.viewer.url,
+    })
+}
+
+pub async fn get() -> surf::Result<String> {
+    Ok(get_profile().await?.login)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_profile_url() {
+        let res: res::Res = serde_json::from_str(
+            r#"{"data":{"viewer":{"login":"octocat","url":"https://example.test/octocat"}}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(res.data.viewer.login, "octocat");
+        assert_eq!(res.data.viewer.url, "https://example.test/octocat");
+    }
 }

--- a/src/query/viewer.graphql
+++ b/src/query/viewer.graphql
@@ -1,5 +1,6 @@
 query {
   viewer {
     login
+    url
   }
 }


### PR DESCRIPTION
## Summary
- Add `p` as a TUI shortcut to open the signed-in viewer's GitHub profile in the browser.
- Cache the viewer login when contributions are loaded so the profile URL can be built locally.
- Update the TUI help text and README to document the new shortcut.
- Add unit coverage for the profile URL helper and help text.

## Testing
- `cargo fmt`
- `cargo test --locked`