### PR TITLE
Simplify TUI auto-reload parsing

### DIFF
--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -1777,7 +1777,7 @@ fn clear_expired_status(app: &mut App) {
     }
 }
 
-pub async fn run(slugs: Vec<String>, auto_reload_secs: Option<u64>) -> surf::Result<()> {
+pub async fn run(slugs: Vec<String>, auto_reload_secs: u64) -> surf::Result<()> {
     let slugs = if slugs.is_empty() {
         vec![crate::cmd::viewer::get().await?]
     } else {
@@ -1789,7 +1789,7 @@ pub async fn run(slugs: Vec<String>, auto_reload_secs: Option<u64>) -> surf::Res
         specs.push(Slug::try_from(slug.as_str())?);
     }
 
-    let auto_reload = auto_reload_secs.map(Duration::from_secs);
+    let auto_reload = Some(Duration::from_secs(auto_reload_secs));
     run_tui(specs, auto_reload).await.map_err(|e| {
         surf::Error::from_str(
             surf::StatusCode::InternalServerError,

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -27,6 +27,7 @@ use std::time::{Duration, Instant};
 // Type alias for GraphQL PR node for brevity (reuse prs module types)
 type PrNode = prs::pull_request::PullRequest;
 const SEARCH_HISTORY_LIMIT: usize = 100;
+pub const AUTO_RELOAD_DEFAULT_SECS: u64 = 300;
 pub const AUTO_RELOAD_MIN_SECS: u64 = 60;
 
 impl MergeStateStatus {

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,23 +116,15 @@ mod tests {
         match opt.command {
             Command::Tui { slug, auto_reload } => {
                 assert_eq!(slug, vec!["foo".to_string()]);
-                assert_eq!(auto_reload, Some(300));
+                assert_eq!(auto_reload, cmd::tui::AUTO_RELOAD_DEFAULT_SECS);
             }
             _ => panic!("expected tui command"),
         }
     }
 
     #[test]
-    fn tui_auto_reload_flag_uses_default_interval() {
-        let opt =
-            Opt::try_parse_from(["gh-chk", "tui", "--auto-reload", "foo"]).expect("parse args");
-        match opt.command {
-            Command::Tui { slug, auto_reload } => {
-                assert_eq!(slug, vec!["foo".to_string()]);
-                assert_eq!(auto_reload, Some(300));
-            }
-            _ => panic!("expected tui command"),
-        }
+    fn tui_auto_reload_requires_explicit_interval_when_present() {
+        assert!(Opt::try_parse_from(["gh-chk", "tui", "--auto-reload", "foo"]).is_err());
     }
 
     #[test]
@@ -142,7 +134,7 @@ mod tests {
         match opt.command {
             Command::Tui { slug, auto_reload } => {
                 assert_eq!(slug, vec!["foo".to_string()]);
-                assert_eq!(auto_reload, Some(60));
+                assert_eq!(auto_reload, 60);
             }
             _ => panic!("expected tui command"),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ enum Command {
             value_name = "SECONDS",
             num_args = 0..=1,
             require_equals = true,
+            default_value = "300",
             default_missing_value = "300",
             value_parser = clap::value_parser!(u64).range(cmd::tui::AUTO_RELOAD_MIN_SECS..),
             help = "Auto-reload the PR list every SECONDS (default: 300, min: 60)"

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,16 +30,12 @@ enum Command {
     /// Interactive TUI for pull requests
     Tui {
         #[clap(
-            long = "auto-reload",
+            long,
             value_name = "SECONDS",
-            num_args = 0..=1,
-            require_equals = true,
-            default_value = "300",
-            default_missing_value = "300",
-            value_parser = clap::value_parser!(u64).range(cmd::tui::AUTO_RELOAD_MIN_SECS..),
-            help = "Auto-reload the PR list every SECONDS (default: 300, min: 60)"
+            default_value_t = cmd::tui::AUTO_RELOAD_DEFAULT_SECS,
+            value_parser = clap::value_parser!(u64).range(cmd::tui::AUTO_RELOAD_MIN_SECS..)
         )]
-        auto_reload: Option<u64>,
+        auto_reload: u64,
         slug: Vec<String>,
     },
     /// Show issues of the repository or user

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,18 @@ mod tests {
     use super::*;
 
     #[test]
+    fn tui_auto_reload_defaults_to_enabled() {
+        let opt = Opt::try_parse_from(["gh-chk", "tui", "foo"]).expect("parse args");
+        match opt.command {
+            Command::Tui { slug, auto_reload } => {
+                assert_eq!(slug, vec!["foo".to_string()]);
+                assert_eq!(auto_reload, Some(300));
+            }
+            _ => panic!("expected tui command"),
+        }
+    }
+
+    #[test]
     fn tui_auto_reload_flag_uses_default_interval() {
         let opt =
             Opt::try_parse_from(["gh-chk", "tui", "--auto-reload", "foo"]).expect("parse args");

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,7 +123,8 @@ mod tests {
     }
 
     #[test]
-    fn tui_auto_reload_requires_explicit_interval_when_present() {
+    fn tui_auto_reload_rejects_invalid_interval() {
+        assert!(Opt::try_parse_from(["gh-chk", "tui", "--auto-reload"]).is_err());
         assert!(Opt::try_parse_from(["gh-chk", "tui", "--auto-reload", "foo"]).is_err());
     }
 


### PR DESCRIPTION
## Summary
- Move the TUI auto-reload default into `tui.rs`
- Simplify the clap field to a plain `u64` with a 300-second default
- Update tests to cover the default, explicit values, and invalid missing values

## Testing
- `cargo test --locked`