### PR TITLE
Mark PRs that originate from Dependabot alerts

### DIFF
--- a/src/cmd/prs.rs
+++ b/src/cmd/prs.rs
@@ -1,6 +1,7 @@
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::collections::HashSet;
 use std::fmt::{Debug, Display};
 
 use crate::cmd::prs::pull_request::PullRequest;
@@ -41,6 +42,8 @@ nestruct::nest! {
         id: String,
         title: String,
         url: String,
+        #[serde(default)]
+        dependabot_alert_origin: bool,
         created_at: String,
         merge_state_status: crate::cmd::prs::MergeStateStatus,
         review_decision: crate::cmd::prs::ReviewDecision?,
@@ -109,6 +112,13 @@ impl pull_request::PullRequest {
             None => String::default(),
         }
     }
+    fn dependabot_alert_status(&self) -> &'static str {
+        if self.dependabot_alert_origin {
+            "[dep-alert]"
+        } else {
+            ""
+        }
+    }
     pub fn ci_status(&self) -> String {
         match self
             .commits
@@ -124,7 +134,7 @@ impl pull_request::PullRequest {
     }
     fn colorized_string(&self) -> String {
         format!(
-            "{:>6} {} {} {} {} {} {}",
+            "{:>6} {} {} {} {} {} {} {}",
             format!("#{}", self.number).bold(),
             self.merge_state_status.to_emoji(),
             self.merge_state_status.colorize(&self.url),
@@ -133,6 +143,7 @@ impl pull_request::PullRequest {
                 .as_ref()
                 .map(|rd| rd.colorize(&format!("[{}]", rd)))
                 .unwrap_or_default(),
+            self.dependabot_alert_status(),
             self.review_requests(),
             format!("({})", self.created_date()).bright_black()
         )
@@ -143,12 +154,13 @@ impl Display for pull_request::PullRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "#{} {} {} {} {} {} ({})",
+            "#{} {} {} {} {} {} {} ({})",
             self.number,
             self.merge_state_status.to_emoji(),
             self.slug(),
             self.title,
             self.review_status(),
+            self.dependabot_alert_status(),
             self.review_requests(),
             self.created_date()
         )
@@ -166,6 +178,48 @@ nestruct::nest! {
             }
         }
     }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DependabotAlertPullRequestIdsRes {
+    data: DependabotAlertPullRequestIdsData,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DependabotAlertPullRequestIdsData {
+    repository: Option<DependabotAlertRepository>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DependabotAlertRepository {
+    vulnerability_alerts: Option<DependabotAlertConnection>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DependabotAlertConnection {
+    nodes: Option<Vec<Option<DependabotAlert>>>,
+    page_info: page_info::PageInfo,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DependabotAlert {
+    dependabot_update: Option<DependabotUpdate>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DependabotUpdate {
+    pull_request: Option<DependabotAlertPullRequest>,
+}
+
+#[derive(Deserialize)]
+struct DependabotAlertPullRequest {
+    id: String,
 }
 
 nestruct::nest! {
@@ -488,8 +542,87 @@ async fn search_prs(query: &str) -> surf::Result<Vec<PullRequest>> {
         json!({ "query": query_doc, "operationName": "SearchPrs", "variables": v })
     })
     .await?;
+    mark_dependabot_alert_origins(&mut prs).await;
     prs.sort();
     Ok(prs)
+}
+
+async fn mark_dependabot_alert_origins(prs: &mut [PullRequest]) {
+    let repos: HashSet<(String, String)> = prs
+        .iter()
+        .map(|pr| {
+            (
+                pr.repository.owner.login.clone(),
+                pr.repository.name.clone(),
+            )
+        })
+        .collect();
+    let mut handles = Vec::with_capacity(repos.len());
+
+    for (owner, name) in repos {
+        handles.push(async_std::task::spawn(async move {
+            fetch_dependabot_alert_pr_ids(&owner, &name).await
+        }));
+    }
+
+    let mut alert_pr_ids = HashSet::new();
+    for handle in handles {
+        if let Ok(ids) = handle.await {
+            alert_pr_ids.extend(ids);
+        }
+    }
+
+    for pr in prs {
+        pr.dependabot_alert_origin = alert_pr_ids.contains(&pr.id);
+    }
+}
+
+async fn fetch_dependabot_alert_pr_ids(owner: &str, name: &str) -> surf::Result<HashSet<String>> {
+    let query_doc = include_str!("../query/prs.graphql");
+    let mut after: Option<String> = None;
+    let mut ids = HashSet::new();
+
+    loop {
+        let v = json!({ "owner": owner, "name": name, "after": after });
+        let q = json!({
+            "query": query_doc,
+            "operationName": "GetDependabotAlertPullRequestIds",
+            "variables": v,
+        });
+        let res = graphql::query::<DependabotAlertPullRequestIdsRes>(&q).await?;
+        let Some(repository) = res.data.repository else {
+            break;
+        };
+        let Some(alerts) = repository.vulnerability_alerts else {
+            break;
+        };
+        let has_next_page = alerts.page_info.has_next_page;
+        let end_cursor = alerts.page_info.end_cursor;
+
+        if let Some(nodes) = alerts.nodes {
+            for alert in nodes.into_iter().flatten() {
+                if let Some(update) = alert.dependabot_update
+                    && let Some(pr) = update.pull_request
+                {
+                    ids.insert(pr.id);
+                }
+            }
+        }
+
+        if !has_next_page {
+            break;
+        }
+
+        after = end_cursor;
+        if after.is_none() {
+            return Err(surf::Error::from_str(
+                surf::StatusCode::InternalServerError,
+                "Inconsistent GraphQL pagination: has_next_page is true but next_after is None",
+            ));
+        }
+    }
+
+    Ok(ids)
 }
 
 pub async fn approve_pr(pr_id: &str) -> surf::Result<()> {

--- a/src/cmd/prs.rs
+++ b/src/cmd/prs.rs
@@ -623,7 +623,7 @@ async fn fetch_dependabot_alert_pr_ids(owner: &str, name: &str) -> surf::Result<
         if after.is_none() {
             return Err(surf::Error::from_str(
                 surf::StatusCode::InternalServerError,
-                "Inconsistent GraphQL pagination: has_next_page is true but next_after is None",
+                "Inconsistent GraphQL pagination: has_next_page is true but end_cursor is None",
             ));
         }
     }

--- a/src/cmd/prs.rs
+++ b/src/cmd/prs.rs
@@ -8,6 +8,8 @@ use crate::cmd::prs::pull_request::PullRequest;
 use crate::slug::Slug;
 use crate::{config, graphql};
 
+const DEPENDABOT_ALERT_LOOKUP_CONCURRENCY: usize = 8;
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(tag = "__typename")]
 pub enum RequestedReviewer {
@@ -548,7 +550,7 @@ async fn search_prs(query: &str) -> surf::Result<Vec<PullRequest>> {
 }
 
 async fn mark_dependabot_alert_origins(prs: &mut [PullRequest]) {
-    let repos: HashSet<(String, String)> = prs
+    let repos: Vec<(String, String)> = prs
         .iter()
         .map(|pr| {
             (
@@ -556,19 +558,23 @@ async fn mark_dependabot_alert_origins(prs: &mut [PullRequest]) {
                 pr.repository.name.clone(),
             )
         })
+        .collect::<HashSet<_>>()
+        .into_iter()
         .collect();
-    let mut handles = Vec::with_capacity(repos.len());
-
-    for (owner, name) in repos {
-        handles.push(async_std::task::spawn(async move {
-            fetch_dependabot_alert_pr_ids(&owner, &name).await
-        }));
-    }
 
     let mut alert_pr_ids = HashSet::new();
-    for handle in handles {
-        if let Ok(ids) = handle.await {
-            alert_pr_ids.extend(ids);
+    for chunk in repos.chunks(DEPENDABOT_ALERT_LOOKUP_CONCURRENCY) {
+        let mut handles = Vec::with_capacity(chunk.len());
+        for (owner, name) in chunk.iter().cloned() {
+            handles.push(async_std::task::spawn(async move {
+                fetch_dependabot_alert_pr_ids(&owner, &name).await
+            }));
+        }
+
+        for handle in handles {
+            if let Ok(ids) = handle.await {
+                alert_pr_ids.extend(ids);
+            }
         }
     }
 

--- a/src/cmd/prs.rs
+++ b/src/cmd/prs.rs
@@ -563,19 +563,33 @@ async fn mark_dependabot_alert_origins(prs: &mut [PullRequest]) {
         .collect();
 
     let mut alert_pr_ids = HashSet::new();
+    let mut lookup_errors = Vec::new();
     for chunk in repos.chunks(DEPENDABOT_ALERT_LOOKUP_CONCURRENCY) {
         let mut handles = Vec::with_capacity(chunk.len());
         for (owner, name) in chunk.iter().cloned() {
-            handles.push(async_std::task::spawn(async move {
-                fetch_dependabot_alert_pr_ids(&owner, &name).await
-            }));
+            let repo = format!("{}/{}", owner, name);
+            handles.push((
+                repo,
+                async_std::task::spawn(async move {
+                    fetch_dependabot_alert_pr_ids(&owner, &name).await
+                }),
+            ));
         }
 
-        for handle in handles {
-            if let Ok(ids) = handle.await {
-                alert_pr_ids.extend(ids);
+        for (repo, handle) in handles {
+            match handle.await {
+                Ok(ids) => alert_pr_ids.extend(ids),
+                Err(err) => lookup_errors.push(format!("{}: {}", repo, err)),
             }
         }
+    }
+
+    if let Some(first_error) = lookup_errors.first() {
+        eprintln!(
+            "warning: Dependabot alert lookup failed for {} repo(s); [dep-alert] markers may be incomplete. First error: {}",
+            lookup_errors.len(),
+            first_error
+        );
     }
 
     for pr in prs {

--- a/src/cmd/prs.rs
+++ b/src/cmd/prs.rs
@@ -1,7 +1,7 @@
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Display};
 
 use crate::cmd::prs::pull_request::PullRequest;
@@ -550,28 +550,28 @@ async fn search_prs(query: &str) -> surf::Result<Vec<PullRequest>> {
 }
 
 async fn mark_dependabot_alert_origins(prs: &mut [PullRequest]) {
-    let repos: Vec<(String, String)> = prs
-        .iter()
-        .map(|pr| {
-            (
+    let mut repo_pr_ids: HashMap<(String, String), HashSet<String>> = HashMap::new();
+    for pr in prs.iter() {
+        repo_pr_ids
+            .entry((
                 pr.repository.owner.login.clone(),
                 pr.repository.name.clone(),
-            )
-        })
-        .collect::<HashSet<_>>()
-        .into_iter()
-        .collect();
+            ))
+            .or_default()
+            .insert(pr.id.clone());
+    }
+    let repos: Vec<((String, String), HashSet<String>)> = repo_pr_ids.into_iter().collect();
 
     let mut alert_pr_ids = HashSet::new();
     let mut lookup_errors = Vec::new();
     for chunk in repos.chunks(DEPENDABOT_ALERT_LOOKUP_CONCURRENCY) {
         let mut handles = Vec::with_capacity(chunk.len());
-        for (owner, name) in chunk.iter().cloned() {
+        for ((owner, name), target_pr_ids) in chunk.iter().cloned() {
             let repo = format!("{}/{}", owner, name);
             handles.push((
                 repo,
                 async_std::task::spawn(async move {
-                    fetch_dependabot_alert_pr_ids(&owner, &name).await
+                    fetch_dependabot_alert_pr_ids(&owner, &name, &target_pr_ids).await
                 }),
             ));
         }
@@ -597,7 +597,11 @@ async fn mark_dependabot_alert_origins(prs: &mut [PullRequest]) {
     }
 }
 
-async fn fetch_dependabot_alert_pr_ids(owner: &str, name: &str) -> surf::Result<HashSet<String>> {
+async fn fetch_dependabot_alert_pr_ids(
+    owner: &str,
+    name: &str,
+    target_pr_ids: &HashSet<String>,
+) -> surf::Result<HashSet<String>> {
     let query_doc = include_str!("../query/prs.graphql");
     let mut after: Option<String> = None;
     let mut ids = HashSet::new();
@@ -623,10 +627,15 @@ async fn fetch_dependabot_alert_pr_ids(owner: &str, name: &str) -> surf::Result<
             for alert in nodes.into_iter().flatten() {
                 if let Some(update) = alert.dependabot_update
                     && let Some(pr) = update.pull_request
+                    && target_pr_ids.contains(&pr.id)
                 {
                     ids.insert(pr.id);
                 }
             }
+        }
+
+        if ids.len() == target_pr_ids.len() {
+            break;
         }
 
         if !has_next_page {

--- a/src/cmd/prs.rs
+++ b/src/cmd/prs.rs
@@ -10,6 +10,75 @@ use crate::{config, graphql};
 
 const DEPENDABOT_ALERT_LOOKUP_CONCURRENCY: usize = 8;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DependabotAlertLookupWarning {
+    failed_repos: usize,
+    first_error: String,
+}
+
+impl DependabotAlertLookupWarning {
+    fn from_errors(errors: Vec<String>) -> Option<Self> {
+        let failed_repos = errors.len();
+        let first_error = errors.into_iter().next()?;
+        Some(Self {
+            failed_repos,
+            first_error,
+        })
+    }
+
+    fn merge(&mut self, other: Self) {
+        self.failed_repos += other.failed_repos;
+    }
+
+    pub fn message(&self) -> String {
+        format!(
+            "Dependabot alert lookup failed for {} repo(s); [dep-alert] markers may be incomplete. First error: {}",
+            self.failed_repos, self.first_error
+        )
+    }
+}
+
+impl Display for DependabotAlertLookupWarning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "warning: {}", self.message())
+    }
+}
+
+pub struct PullRequestFetchResult {
+    pub prs: Vec<PullRequest>,
+    pub warning: Option<DependabotAlertLookupWarning>,
+}
+
+impl PullRequestFetchResult {
+    fn new(prs: Vec<PullRequest>, warning: Option<DependabotAlertLookupWarning>) -> Self {
+        Self { prs, warning }
+    }
+
+    fn extend(&mut self, mut other: Self) {
+        self.prs.append(&mut other.prs);
+        merge_dependabot_alert_warning(&mut self.warning, other.warning);
+    }
+}
+
+fn merge_dependabot_alert_warning(
+    target: &mut Option<DependabotAlertLookupWarning>,
+    incoming: Option<DependabotAlertLookupWarning>,
+) {
+    let Some(incoming) = incoming else {
+        return;
+    };
+    match target {
+        Some(target) => target.merge(incoming),
+        None => *target = Some(incoming),
+    }
+}
+
+fn print_dependabot_alert_warning(warning: Option<&DependabotAlertLookupWarning>) {
+    if let Some(warning) = warning {
+        eprintln!("{}", warning);
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(tag = "__typename")]
 pub enum RequestedReviewer {
@@ -468,15 +537,18 @@ pub async fn check(slugs: Vec<String>, merge: bool) -> surf::Result<()> {
             .iter()
             .map(|s| Slug::try_from(s.as_str()))
             .collect::<Result<_, _>>()?;
-        let prs = fetch_prs(&specs).await?;
-        println!("{}", serde_json::to_string_pretty(&prs).unwrap());
+        let result = fetch_prs_with_warnings(&specs).await?;
+        print_dependabot_alert_warning(result.warning.as_ref());
+        println!("{}", serde_json::to_string_pretty(&result.prs).unwrap());
         return Ok(());
     }
 
     if merge {
         for slug in slugs {
             println!("{}", slug.bright_blue());
-            let prs = fetch_prs_for_spec(Slug::try_from(slug.as_str())?).await?;
+            let result = fetch_prs_for_spec_with_warnings(Slug::try_from(slug.as_str())?).await?;
+            print_dependabot_alert_warning(result.warning.as_ref());
+            let prs = result.prs;
             for pr in &prs {
                 println!("{}", pr.colorized_string());
                 if pr.merge_state_status == MergeStateStatus::Clean {
@@ -495,12 +567,16 @@ pub async fn check(slugs: Vec<String>, merge: bool) -> surf::Result<()> {
         .collect::<Result<_, _>>()?;
     let mut handles = Vec::with_capacity(specs.len());
     for spec in specs.into_iter() {
-        handles.push(async_std::task::spawn(fetch_prs_for_spec(spec)));
+        handles.push(async_std::task::spawn(fetch_prs_for_spec_with_warnings(
+            spec,
+        )));
     }
 
     for (slug, handle) in slugs.into_iter().zip(handles) {
         println!("{}", slug.bright_blue());
-        let prs = handle.await?;
+        let result = handle.await?;
+        print_dependabot_alert_warning(result.warning.as_ref());
+        let prs = result.prs;
         for pr in &prs {
             println!("{}", pr.colorized_string());
         }
@@ -508,48 +584,55 @@ pub async fn check(slugs: Vec<String>, merge: bool) -> surf::Result<()> {
     Ok(())
 }
 
-async fn fetch_prs_for_spec(spec: Slug) -> surf::Result<Vec<PullRequest>> {
+async fn fetch_prs_for_spec_with_warnings(spec: Slug) -> surf::Result<PullRequestFetchResult> {
     match spec {
-        Slug::Owner(owner) => fetch_owner_prs(&owner).await,
-        Slug::Repo { owner, name } => fetch_repo_prs(&owner, &name).await,
+        Slug::Owner(owner) => fetch_owner_prs_with_warnings(&owner).await,
+        Slug::Repo { owner, name } => fetch_repo_prs_with_warnings(&owner, &name).await,
     }
 }
 
-pub async fn fetch_prs(specs: &[Slug]) -> surf::Result<Vec<PullRequest>> {
-    let mut all_prs: Vec<PullRequest> = Vec::new();
+pub async fn fetch_prs_with_warnings(specs: &[Slug]) -> surf::Result<PullRequestFetchResult> {
+    let mut result = PullRequestFetchResult::new(Vec::new(), None);
     let mut handles = Vec::with_capacity(specs.len());
     for spec in specs.iter().cloned() {
-        handles.push(async_std::task::spawn(fetch_prs_for_spec(spec)));
+        handles.push(async_std::task::spawn(fetch_prs_for_spec_with_warnings(
+            spec,
+        )));
     }
     for handle in handles {
-        all_prs.append(&mut handle.await?);
+        result.extend(handle.await?);
     }
-    Ok(all_prs)
+    Ok(result)
 }
 
-async fn fetch_owner_prs(owner: &str) -> surf::Result<Vec<PullRequest>> {
+async fn fetch_owner_prs_with_warnings(owner: &str) -> surf::Result<PullRequestFetchResult> {
     let query = format!("is:pr is:open user:{}", owner);
     search_prs(&query).await
 }
 
-pub async fn fetch_repo_prs(owner: &str, name: &str) -> surf::Result<Vec<PullRequest>> {
+pub async fn fetch_repo_prs_with_warnings(
+    owner: &str,
+    name: &str,
+) -> surf::Result<PullRequestFetchResult> {
     let query = format!("is:pr is:open repo:{}/{}", owner, name);
     search_prs(&query).await
 }
 
-async fn search_prs(query: &str) -> surf::Result<Vec<PullRequest>> {
+async fn search_prs(query: &str) -> surf::Result<PullRequestFetchResult> {
     let query_doc = include_str!("../query/prs.graphql");
     let mut prs: Vec<PullRequest> = graphql::query_all_pages::<search_res::SearchRes>(|after| {
         let v = json!({ "query": query, "after": after });
         json!({ "query": query_doc, "operationName": "SearchPrs", "variables": v })
     })
     .await?;
-    mark_dependabot_alert_origins(&mut prs).await;
+    let warning = mark_dependabot_alert_origins(&mut prs).await;
     prs.sort();
-    Ok(prs)
+    Ok(PullRequestFetchResult::new(prs, warning))
 }
 
-async fn mark_dependabot_alert_origins(prs: &mut [PullRequest]) {
+async fn mark_dependabot_alert_origins(
+    prs: &mut [PullRequest],
+) -> Option<DependabotAlertLookupWarning> {
     let mut repo_pr_ids: HashMap<(String, String), HashSet<String>> = HashMap::new();
     for pr in prs.iter() {
         repo_pr_ids
@@ -584,17 +667,11 @@ async fn mark_dependabot_alert_origins(prs: &mut [PullRequest]) {
         }
     }
 
-    if let Some(first_error) = lookup_errors.first() {
-        eprintln!(
-            "warning: Dependabot alert lookup failed for {} repo(s); [dep-alert] markers may be incomplete. First error: {}",
-            lookup_errors.len(),
-            first_error
-        );
-    }
-
     for pr in prs {
         pr.dependabot_alert_origin = alert_pr_ids.contains(&pr.id);
     }
+
+    DependabotAlertLookupWarning::from_errors(lookup_errors)
 }
 
 async fn fetch_dependabot_alert_pr_ids(

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -1897,6 +1897,29 @@ mod tests {
     }
 
     #[test]
+    fn pr_list_marks_dependabot_alert_origin() {
+        let mut app = empty_app(AppMode::Prs);
+        let mut pr = test_pr("one", 1);
+        pr.dependabot_alert_origin = true;
+        app.prs = vec![pr];
+
+        let mut terminal =
+            Terminal::new(ratatui::backend::TestBackend::new(120, 5)).expect("terminal");
+        terminal
+            .draw(|frame| render_pr_list(frame, &mut app, frame.area()))
+            .expect("draw");
+
+        let rendered = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(rendered.contains("[dep-alert]"));
+    }
+
+    #[test]
     fn search_history_keeps_latest_unique_queries() {
         let mut history = Vec::new();
         assert!(push_search_history(&mut history, " first "));

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -1,4 +1,6 @@
-use crate::cmd::prs::{self, Commit, CommitGraphEntry, MergeStateStatus, approve_pr, fetch_prs};
+use crate::cmd::prs::{
+    self, Commit, CommitGraphEntry, MergeStateStatus, approve_pr, fetch_prs_with_warnings,
+};
 use crate::cmd::search::{SearchItem, search_code};
 use crate::{slug::Slug, styling};
 use async_std::channel::{Receiver, Sender, TryRecvError};
@@ -109,7 +111,7 @@ type AutoReloadReceiver = Receiver<AutoReloadEvent>;
 
 struct AutoReloadEvent {
     id: u64,
-    result: surf::Result<Vec<PrNode>>,
+    result: surf::Result<prs::PullRequestFetchResult>,
 }
 
 struct AutoReload {
@@ -140,6 +142,10 @@ impl AutoReload {
 fn mark_auto_reload_complete(auto_reload: &mut AutoReload) {
     auto_reload.in_flight = false;
     auto_reload.next_at = Instant::now() + auto_reload.interval;
+}
+
+fn dependabot_warning_status(warning: &prs::DependabotAlertLookupWarning) -> String {
+    format!("⚠️ {}", warning.message())
 }
 
 struct SearchState {
@@ -344,7 +350,12 @@ struct App {
 
 impl App {
     async fn new(specs: Vec<Slug>, auto_reload: Option<Duration>) -> surf::Result<App> {
-        let prs = fetch_prs(&specs).await?;
+        let result = fetch_prs_with_warnings(&specs).await?;
+        let status_message = result.warning.as_ref().map(dependabot_warning_status);
+        let status_clear_at = status_message
+            .as_ref()
+            .map(|_| Instant::now() + Duration::from_millis(3000));
+        let prs = result.prs;
         let mut list_state = ListState::default();
         if !prs.is_empty() {
             list_state.select(Some(0));
@@ -355,8 +366,8 @@ impl App {
             prs,
             list_state,
             should_quit: false,
-            status_message: None,
-            status_clear_at: None,
+            status_message,
+            status_clear_at,
             specs,
             cache: HashMap::new(),
             preview: Preview::default(),
@@ -505,17 +516,26 @@ impl App {
     }
 
     async fn reload(&mut self) {
-        let new_list = match fetch_prs(&self.specs).await {
-            Ok(prs) => prs,
+        let result = match fetch_prs_with_warnings(&self.specs).await {
+            Ok(result) => result,
             Err(e) => {
                 self.set_status(format!("❌ Reload error: {}", e));
                 return;
             }
         };
+        let warning = result.warning;
 
-        self.apply_pr_list_and_restore_selection(new_list);
+        self.apply_pr_list_and_restore_selection(result.prs);
         self.refresh_preview().await;
-        self.set_status(format!("✅ Reloaded. {} PRs.", self.prs.len()));
+        if let Some(warning) = warning {
+            self.set_status(format!(
+                "⚠️ Reloaded. {} PRs. {}",
+                self.prs.len(),
+                warning.message()
+            ));
+        } else {
+            self.set_status(format!("✅ Reloaded. {} PRs.", self.prs.len()));
+        }
 
         if let Err(e) = self.load_contributions().await {
             self.set_status(format!("❌ Contrib load error: {}", e));
@@ -556,7 +576,7 @@ impl App {
         let specs = self.specs.clone();
         let tx = auto_reload.tx.clone();
         async_std::task::spawn(async move {
-            let result = fetch_prs(&specs).await;
+            let result = fetch_prs_with_warnings(&specs).await;
             let _ = tx.send(AutoReloadEvent { id, result }).await;
         });
         self.set_status_persistent("🔄 Auto reloading PRs...");
@@ -573,11 +593,18 @@ impl App {
 
         let show_status = self.mode == AppMode::Prs;
         match event.result {
-            Ok(prs) => {
-                let count = prs.len();
-                self.apply_pr_list_and_restore_selection(prs);
+            Ok(result) => {
+                let count = result.prs.len();
+                let warning = result.warning;
+                self.apply_pr_list_and_restore_selection(result.prs);
                 let queued_preview = show_status && self.queue_preview_if_needed();
-                if show_status && !queued_preview {
+                if show_status && let Some(warning) = warning {
+                    self.set_status(format!(
+                        "⚠️ Auto reloaded. {} PRs. {}",
+                        count,
+                        warning.message()
+                    ));
+                } else if show_status && !queued_preview {
                     self.set_status(format!("✅ Auto reloaded. {} PRs.", count));
                 }
             }
@@ -714,16 +741,23 @@ impl App {
         let owner = pr.repository.owner.login.clone();
         let name = pr.repository.name.clone();
         self.set_status_persistent(format!("🔄 Reloading {}...", pr.numslug()));
-        match prs::fetch_repo_prs(&owner, &name).await {
-            Ok(mut repo_prs) => {
+        match prs::fetch_repo_prs_with_warnings(&owner, &name).await {
+            Ok(result) => {
+                let warning = result.warning;
+                let mut repo_prs = result.prs;
                 self.replace_repo_prs(&owner, &name, &mut repo_prs, Some(pr.id.clone()));
                 self.drop_preview_cache_for(&pr.id);
                 self.refresh_preview().await;
                 let still_present = self.prs.iter().any(|p| p.id == pr.id);
-                if still_present {
-                    self.set_status(format!("✅ Reloaded {}.", pr.numslug()));
+                let status = if still_present {
+                    format!("✅ Reloaded {}.", pr.numslug())
                 } else {
-                    self.set_status(format!("✅ Removed {} (no longer open).", pr.numslug()));
+                    format!("✅ Removed {} (no longer open).", pr.numslug())
+                };
+                if let Some(warning) = warning {
+                    self.set_status(format!("⚠️ {} {}", status, warning.message()));
+                } else {
+                    self.set_status(status);
                 }
             }
             Err(e) => self.set_status(format!("❌ Reload error for {}: {}", pr.numslug(), e)),
@@ -2041,7 +2075,10 @@ mod tests {
         auto_reload.in_flight = true;
         async_std::task::block_on(auto_reload.tx.send(AutoReloadEvent {
             id: 1,
-            result: Ok(vec![test_pr("two", 2)]),
+            result: Ok(prs::PullRequestFetchResult {
+                prs: vec![test_pr("two", 2)],
+                warning: None,
+            }),
         }))
         .expect("send auto-reload event");
         app.auto_reload = Some(auto_reload);
@@ -2081,7 +2118,10 @@ mod tests {
         auto_reload.next_at = Instant::now();
         async_std::task::block_on(auto_reload.tx.send(AutoReloadEvent {
             id: 1,
-            result: Ok(Vec::new()),
+            result: Ok(prs::PullRequestFetchResult {
+                prs: Vec::new(),
+                warning: None,
+            }),
         }))
         .expect("send auto-reload event");
         app.auto_reload = Some(auto_reload);

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -749,15 +749,15 @@ impl App {
                 self.drop_preview_cache_for(&pr.id);
                 self.refresh_preview().await;
                 let still_present = self.prs.iter().any(|p| p.id == pr.id);
-                let status = if still_present {
-                    format!("✅ Reloaded {}.", pr.numslug())
+                let action = if still_present {
+                    format!("Reloaded {}.", pr.numslug())
                 } else {
-                    format!("✅ Removed {} (no longer open).", pr.numslug())
+                    format!("Removed {} (no longer open).", pr.numslug())
                 };
                 if let Some(warning) = warning {
-                    self.set_status(format!("⚠️ {} {}", status, warning.message()));
+                    self.set_status(format!("⚠️ {} {}", action, warning.message()));
                 } else {
-                    self.set_status(status);
+                    self.set_status(format!("✅ {}", action));
                 }
             }
             Err(e) => self.set_status(format!("❌ Reload error for {}: {}", pr.numslug(), e)),

--- a/src/query/prs.graphql
+++ b/src/query/prs.graphql
@@ -66,6 +66,28 @@ query GetPrBody($login: String!, $name: String!, $number: Int!) {
   }
 }
 
+query GetDependabotAlertPullRequestIds(
+  $owner: String!
+  $name: String!
+  $after: String
+) {
+  repository(owner: $owner, name: $name) {
+    vulnerabilityAlerts(first: 100, states: [OPEN], after: $after) {
+      nodes {
+        dependabotUpdate {
+          pullRequest {
+            id
+          }
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+}
+
 mutation MergePullRequest($pullRequestId: ID!) {
   mergePullRequest(input: { pullRequestId: $pullRequestId }) {
     clientMutationId

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -106,6 +106,7 @@ fn prs_output() {
 fn prs_text_includes_review_status() {
     let out = run_cmd(&["-f", "text", "prs", "foo"], "prs");
     assert!(out.contains("[approved]"));
+    assert!(!out.contains("[dep-alert]"));
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -120,6 +120,20 @@ fn prs_text_marks_dependabot_alert_origin() {
 }
 
 #[test]
+fn prs_text_stops_dependabot_alert_lookup_after_matching_prs() {
+    let output = run_output(
+        &["-f", "text", "prs", "foo"],
+        "prs_dependabot_alert_short_circuit",
+    );
+    assert!(output.status.success(), "command failed: {:?}", output);
+    let out = String::from_utf8_lossy(&output.stdout);
+    let err = String::from_utf8_lossy(&output.stderr);
+
+    assert!(out.contains("[dep-alert]"));
+    assert!(!err.contains("warning: Dependabot alert lookup failed"));
+}
+
+#[test]
 fn prs_text_warns_when_dependabot_alert_lookup_fails() {
     let output = run_output(&["-f", "text", "prs", "foo"], "prs_dependabot_alert_error");
     assert!(output.status.success(), "command failed: {:?}", output);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -109,6 +109,12 @@ fn prs_text_includes_review_status() {
 }
 
 #[test]
+fn prs_text_marks_dependabot_alert_origin() {
+    let out = run_cmd(&["-f", "text", "prs", "foo"], "prs_dependabot_alert");
+    assert!(out.contains("[dep-alert]"));
+}
+
+#[test]
 fn prs_text_handles_bot_and_mannequin_reviewers() {
     let out = run_cmd(&["-f", "text", "prs", "foo"], "prs_requested_reviewers");
     assert!(out.contains("[r: dependabot[bot]]"));

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,6 +1,6 @@
 use std::net::{TcpListener, TcpStream};
 use std::path::PathBuf;
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, Command, Output, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -78,9 +78,9 @@ fn start_stub() -> StubServer {
     panic!("stub server did not start");
 }
 
-fn run_cmd(args: &[&str], scenario: &str) -> String {
+fn run_output(args: &[&str], scenario: &str) -> Output {
     let stub = start_stub();
-    let output = Command::new("cargo")
+    Command::new("cargo")
         .args(["run", "--quiet", "--"])
         .args(args)
         .env("NO_COLOR", "1")
@@ -90,7 +90,11 @@ fn run_cmd(args: &[&str], scenario: &str) -> String {
             format!("{}/{}", stub.graphql_base_url, scenario),
         )
         .output()
-        .expect("run command");
+        .expect("run command")
+}
+
+fn run_cmd(args: &[&str], scenario: &str) -> String {
+    let output = run_output(args, scenario);
     assert!(output.status.success(), "command failed: {:?}", output);
     String::from_utf8_lossy(&output.stdout).to_string()
 }
@@ -113,6 +117,19 @@ fn prs_text_includes_review_status() {
 fn prs_text_marks_dependabot_alert_origin() {
     let out = run_cmd(&["-f", "text", "prs", "foo"], "prs_dependabot_alert");
     assert!(out.contains("[dep-alert]"));
+}
+
+#[test]
+fn prs_text_warns_when_dependabot_alert_lookup_fails() {
+    let output = run_output(&["-f", "text", "prs", "foo"], "prs_dependabot_alert_error");
+    assert!(output.status.success(), "command failed: {:?}", output);
+    let out = String::from_utf8_lossy(&output.stdout);
+    let err = String::from_utf8_lossy(&output.stderr);
+
+    assert!(out.contains("Test PR"));
+    assert!(!out.contains("[dep-alert]"));
+    assert!(err.contains("warning: Dependabot alert lookup failed"));
+    assert!(err.contains("[dep-alert] markers may be incomplete"));
 }
 
 #[test]

--- a/tests/data/dependabot_alert_prs.json
+++ b/tests/data/dependabot_alert_prs.json
@@ -1,0 +1,21 @@
+{
+  "data": {
+    "repository": {
+      "vulnerabilityAlerts": {
+        "nodes": [
+          {
+            "dependabotUpdate": {
+              "pullRequest": {
+                "id": "PRID1"
+              }
+            }
+          }
+        ],
+        "pageInfo": {
+          "endCursor": null,
+          "hasNextPage": false
+        }
+      }
+    }
+  }
+}

--- a/tests/data/dependabot_alert_prs_empty.json
+++ b/tests/data/dependabot_alert_prs_empty.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "repository": {
+      "vulnerabilityAlerts": {
+        "nodes": [],
+        "pageInfo": {
+          "endCursor": null,
+          "hasNextPage": false
+        }
+      }
+    }
+  }
+}

--- a/tests/stub/server.py
+++ b/tests/stub/server.py
@@ -22,10 +22,18 @@ def load_json(name: str):
 
 
 def response_for(scenario: str, payload: dict):
+    if payload.get("operationName") == "GetDependabotAlertPullRequestIds":
+        if scenario == "prs_dependabot_alert":
+            return 200, load_json("dependabot_alert_prs.json")
+        return 200, load_json("dependabot_alert_prs_empty.json")
+
     if scenario == "issues":
         return 200, load_json("issues.json")
 
     if scenario == "prs":
+        return 200, load_json("prs.json")
+
+    if scenario == "prs_dependabot_alert":
         return 200, load_json("prs.json")
 
     if scenario == "prs_requested_reviewers":

--- a/tests/stub/server.py
+++ b/tests/stub/server.py
@@ -21,10 +21,39 @@ def load_json(name: str):
     return json.loads((DATA_DIR / name).read_text())
 
 
+def dependabot_alert_pr_page(pr_id: str, end_cursor=None, has_next_page=False):
+    return {
+        "data": {
+            "repository": {
+                "vulnerabilityAlerts": {
+                    "nodes": [
+                        {
+                            "dependabotUpdate": {
+                                "pullRequest": {
+                                    "id": pr_id
+                                }
+                            }
+                        }
+                    ],
+                    "pageInfo": {
+                        "endCursor": end_cursor,
+                        "hasNextPage": has_next_page,
+                    },
+                }
+            }
+        }
+    }
+
+
 def response_for(scenario: str, payload: dict):
     if payload.get("operationName") == "GetDependabotAlertPullRequestIds":
         if scenario == "prs_dependabot_alert_error":
             return 500, {"message": "dependabot alert lookup failed"}
+        if scenario == "prs_dependabot_alert_short_circuit":
+            after = (payload.get("variables") or {}).get("after")
+            if after is None:
+                return 200, dependabot_alert_pr_page("PRID1", "alert-page-1", True)
+            return 500, {"message": f"unexpected alert page request: {after}"}
         if scenario == "prs_dependabot_alert":
             return 200, load_json("dependabot_alert_prs.json")
         return 200, load_json("dependabot_alert_prs_empty.json")
@@ -39,6 +68,9 @@ def response_for(scenario: str, payload: dict):
         return 200, load_json("prs.json")
 
     if scenario == "prs_dependabot_alert_error":
+        return 200, load_json("prs.json")
+
+    if scenario == "prs_dependabot_alert_short_circuit":
         return 200, load_json("prs.json")
 
     if scenario == "prs_requested_reviewers":

--- a/tests/stub/server.py
+++ b/tests/stub/server.py
@@ -23,6 +23,8 @@ def load_json(name: str):
 
 def response_for(scenario: str, payload: dict):
     if payload.get("operationName") == "GetDependabotAlertPullRequestIds":
+        if scenario == "prs_dependabot_alert_error":
+            return 500, {"message": "dependabot alert lookup failed"}
         if scenario == "prs_dependabot_alert":
             return 200, load_json("dependabot_alert_prs.json")
         return 200, load_json("dependabot_alert_prs_empty.json")
@@ -34,6 +36,9 @@ def response_for(scenario: str, payload: dict):
         return 200, load_json("prs.json")
 
     if scenario == "prs_dependabot_alert":
+        return 200, load_json("prs.json")
+
+    if scenario == "prs_dependabot_alert_error":
         return 200, load_json("prs.json")
 
     if scenario == "prs_requested_reviewers":


### PR DESCRIPTION
## Summary
- Add a GraphQL lookup for open vulnerability alerts and match them back to PRs by ID.
- Surface a `[dep-alert]` marker in both text and TUI PR listings when a PR comes from a Dependabot alert.
- Add fixtures and tests to cover the new marker in CLI output and the TUI list.

## Testing
- Added integration coverage for `prs` text output with Dependabot alert PRs.
- Added a TUI render test to verify the alert marker is shown in the PR list.
- Added stubbed GraphQL fixtures for alert-backed and empty alert cases.