### PR TITLE
Highlight Dependabot alerts in the PR TUI

### DIFF
--- a/src/cmd/prs.rs
+++ b/src/cmd/prs.rs
@@ -9,6 +9,7 @@ use crate::slug::Slug;
 use crate::{config, graphql};
 
 const DEPENDABOT_ALERT_LOOKUP_CONCURRENCY: usize = 8;
+pub(crate) const DEPENDABOT_ALERT_BADGE: &str = "[dep-alert]";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DependabotAlertLookupWarning {
@@ -161,13 +162,13 @@ impl pull_request::PullRequest {
     pub fn numslug(&self) -> String {
         format!("#{} in {}", self.number, self.slug())
     }
-    fn created_date(&self) -> &str {
+    pub(crate) fn created_date(&self) -> &str {
         self.created_at
             .split('T')
             .next()
             .unwrap_or(&self.created_at)
     }
-    fn review_requests(&self) -> String {
+    pub(crate) fn review_requests(&self) -> String {
         if self.review_requests.nodes.is_empty() {
             String::default()
         } else if self.review_requests.nodes.len() == 1 {
@@ -177,15 +178,15 @@ impl pull_request::PullRequest {
             format!("[r: {}]", &self.review_requests.nodes.len())
         }
     }
-    fn review_status(&self) -> String {
+    pub(crate) fn review_status(&self) -> String {
         match &self.review_decision {
             Some(rd) => format!("[{}]", rd),
             None => String::default(),
         }
     }
-    fn dependabot_alert_status(&self) -> &'static str {
+    pub(crate) fn dependabot_alert_status(&self) -> &'static str {
         if self.dependabot_alert_origin {
-            "[dep-alert]"
+            DEPENDABOT_ALERT_BADGE
         } else {
             ""
         }

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -1959,6 +1959,7 @@ mod tests {
             .map(|cell| cell.symbol())
             .collect::<String>();
         assert!(rendered.contains("[dep-alert]"));
+        assert_eq!(terminal.backend().buffer()[(1, 1)].fg, Color::Cyan);
     }
 
     #[test]

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -47,14 +47,6 @@ impl MergeStateStatus {
     }
 }
 
-fn pr_list_color(pr: &PrNode) -> Color {
-    if pr.dependabot_alert_origin {
-        Color::Cyan
-    } else {
-        pr.merge_state_status.to_color()
-    }
-}
-
 #[derive(Debug, Clone, Copy, Default)]
 struct Preview {
     mode: Option<PreviewMode>,
@@ -991,9 +983,7 @@ fn layout_main_chunks(area: Rect, preview_mode: Option<PreviewMode>) -> Rc<[Rect
 fn build_pr_list(app: &App) -> List<'static> {
     let mut items: Vec<ListItem> = Vec::new();
     for pr in &app.prs {
-        let line = format!("{} {}", pr, pr.ci_status());
-        let styled = Span::styled(line, Style::default().fg(pr_list_color(pr)));
-        items.push(ListItem::new(Line::from(styled)));
+        items.push(ListItem::new(pr_list_line(pr)));
     }
     let mut title = format!("Pull Requests: total {}", app.prs.len());
     if let Some(auto_reload) = &app.auto_reload {
@@ -1005,6 +995,33 @@ fn build_pr_list(app: &App) -> List<'static> {
         .block(block)
         .highlight_style(highlight_style)
         .highlight_symbol(">> ")
+}
+
+fn pr_list_line(pr: &PrNode) -> Line<'static> {
+    let style = Style::default().fg(pr.merge_state_status.to_color());
+    let mut spans = vec![
+        Span::styled(format!("#{}", pr.number), style),
+        Span::styled(" ", style),
+        Span::styled(pr.merge_state_status.to_emoji(), style),
+        Span::styled(" ", style),
+        Span::styled(pr.slug(), style),
+        Span::styled(" ", style),
+        Span::styled(pr.title.clone(), style),
+        Span::styled(" ", style),
+        Span::styled(pr.review_status(), style),
+        Span::styled(" ", style),
+    ];
+    let alert = pr.dependabot_alert_status();
+    if !alert.is_empty() {
+        spans.push(Span::styled(alert, Style::default().fg(Color::Cyan)));
+    }
+    spans.extend([
+        Span::styled(" ", style),
+        Span::styled(pr.review_requests(), style),
+        Span::styled(format!(" ({}) ", pr.created_date()), style),
+        Span::styled(pr.ci_status(), style),
+    ]);
+    Line::from(spans)
 }
 
 fn build_preview_text(app: &App) -> Text<'static> {

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -47,6 +47,14 @@ impl MergeStateStatus {
     }
 }
 
+fn pr_list_color(pr: &PrNode) -> Color {
+    if pr.dependabot_alert_origin {
+        Color::Cyan
+    } else {
+        pr.merge_state_status.to_color()
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default)]
 struct Preview {
     mode: Option<PreviewMode>,
@@ -984,7 +992,7 @@ fn build_pr_list(app: &App) -> List<'static> {
     let mut items: Vec<ListItem> = Vec::new();
     for pr in &app.prs {
         let line = format!("{} {}", pr, pr.ci_status());
-        let styled = Span::styled(line, Style::default().fg(pr.merge_state_status.to_color()));
+        let styled = Span::styled(line, Style::default().fg(pr_list_color(pr)));
         items.push(ListItem::new(Line::from(styled)));
     }
     let mut title = format!("Pull Requests: total {}", app.prs.len());

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -1976,7 +1976,31 @@ mod tests {
             .map(|cell| cell.symbol())
             .collect::<String>();
         assert!(rendered.contains("[dep-alert]"));
-        assert_eq!(terminal.backend().buffer()[(1, 1)].fg, Color::Cyan);
+        let buffer = terminal.backend().buffer();
+        let alert_x = find_row_text_x(buffer, 1, prs::DEPENDABOT_ALERT_BADGE);
+        assert_eq!(buffer[(1, 1)].fg, Color::Green);
+        for x in alert_x..alert_x + prs::DEPENDABOT_ALERT_BADGE.len() as u16 {
+            assert_eq!(buffer[(x, 1)].fg, Color::Cyan);
+        }
+        assert_eq!(
+            buffer[(alert_x + prs::DEPENDABOT_ALERT_BADGE.len() as u16, 1)].fg,
+            Color::Green
+        );
+    }
+
+    fn find_row_text_x(buffer: &ratatui::buffer::Buffer, y: u16, needle: &str) -> u16 {
+        let symbols = needle.chars().map(|c| c.to_string()).collect::<Vec<_>>();
+        let max_x = buffer.area.width.saturating_sub(symbols.len() as u16);
+        for x in 0..=max_x {
+            if symbols
+                .iter()
+                .enumerate()
+                .all(|(i, symbol)| buffer[(x + i as u16, y)].symbol() == symbol)
+            {
+                return x;
+            }
+        }
+        panic!("{needle:?} not found on row {y}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Render a dedicated cyan `[dep-alert]` badge in the PR list instead of folding it into the generic line style
- Expose the PR formatting helpers needed by the TUI line builder
- Add a rendering test that verifies the alert badge color is preserved in the buffer

## Testing
- Added/updated TUI rendering coverage for the Dependabot alert badge
- Not run (not requested)