### PR TITLE
Improve PR list styling in the TUI

### DIFF
--- a/src/cmd/prs.rs
+++ b/src/cmd/prs.rs
@@ -9,6 +9,7 @@ use crate::slug::Slug;
 use crate::{config, graphql};
 
 const DEPENDABOT_ALERT_LOOKUP_CONCURRENCY: usize = 8;
+pub(crate) const DEPENDABOT_ALERT_BADGE: &str = "[dep-alert]";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DependabotAlertLookupWarning {
@@ -161,13 +162,13 @@ impl pull_request::PullRequest {
     pub fn numslug(&self) -> String {
         format!("#{} in {}", self.number, self.slug())
     }
-    fn created_date(&self) -> &str {
+    pub(crate) fn created_date(&self) -> &str {
         self.created_at
             .split('T')
             .next()
             .unwrap_or(&self.created_at)
     }
-    fn review_requests(&self) -> String {
+    pub(crate) fn review_requests(&self) -> String {
         if self.review_requests.nodes.is_empty() {
             String::default()
         } else if self.review_requests.nodes.len() == 1 {
@@ -177,15 +178,15 @@ impl pull_request::PullRequest {
             format!("[r: {}]", &self.review_requests.nodes.len())
         }
     }
-    fn review_status(&self) -> String {
+    pub(crate) fn review_status(&self) -> String {
         match &self.review_decision {
             Some(rd) => format!("[{}]", rd),
             None => String::default(),
         }
     }
-    fn dependabot_alert_status(&self) -> &'static str {
+    pub(crate) fn dependabot_alert_status(&self) -> &'static str {
         if self.dependabot_alert_origin {
-            "[dep-alert]"
+            DEPENDABOT_ALERT_BADGE
         } else {
             ""
         }

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -1029,7 +1029,7 @@ fn pr_list_line(pr: &PrNode) -> Line<'static> {
 
 fn review_status_style(pr: &PrNode, fallback: Style) -> Style {
     match pr.review_decision.as_ref() {
-        Some(prs::ReviewDecision::Approved) => Style::default().fg(Color::Green),
+        Some(prs::ReviewDecision::Approved) => Style::default().fg(Color::Magenta),
         Some(prs::ReviewDecision::ChangesRequested) => Style::default().fg(Color::Red),
         Some(prs::ReviewDecision::ReviewRequired) => Style::default().fg(Color::Yellow),
         None => fallback,
@@ -1993,7 +1993,7 @@ mod tests {
     #[test]
     fn pr_list_line_highlights_review_decision() {
         for (decision, badge, color) in [
-            (prs::ReviewDecision::Approved, "[approved]", Color::Green),
+            (prs::ReviewDecision::Approved, "[approved]", Color::Magenta),
             (
                 prs::ReviewDecision::ChangesRequested,
                 "[changes requested]",

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -983,9 +983,7 @@ fn layout_main_chunks(area: Rect, preview_mode: Option<PreviewMode>) -> Rc<[Rect
 fn build_pr_list(app: &App) -> List<'static> {
     let mut items: Vec<ListItem> = Vec::new();
     for pr in &app.prs {
-        let line = format!("{} {}", pr, pr.ci_status());
-        let styled = Span::styled(line, Style::default().fg(pr.merge_state_status.to_color()));
-        items.push(ListItem::new(Line::from(styled)));
+        items.push(ListItem::new(pr_list_line(pr)));
     }
     let mut title = format!("Pull Requests: total {}", app.prs.len());
     if let Some(auto_reload) = &app.auto_reload {
@@ -997,6 +995,60 @@ fn build_pr_list(app: &App) -> List<'static> {
         .block(block)
         .highlight_style(highlight_style)
         .highlight_symbol(">> ")
+}
+
+fn pr_list_line(pr: &PrNode) -> Line<'static> {
+    let style = Style::default().fg(pr.merge_state_status.to_color());
+    let mut spans = Vec::new();
+    push_pr_field(&mut spans, format!("#{}", pr.number), style);
+    push_pr_field(&mut spans, pr.merge_state_status.to_emoji(), style);
+    push_pr_field(&mut spans, pr.slug(), style);
+    push_pr_field(&mut spans, pr.title.clone(), style);
+    push_pr_field(
+        &mut spans,
+        pr.review_status(),
+        review_status_style(pr, style),
+    );
+    let alert = pr.dependabot_alert_status();
+    if !alert.is_empty() {
+        push_pr_span(
+            &mut spans,
+            Span::styled(alert, Style::default().fg(Color::Cyan)),
+            style,
+        );
+    }
+    push_pr_field(
+        &mut spans,
+        pr.review_requests(),
+        Style::default().fg(Color::Yellow),
+    );
+    push_pr_field(&mut spans, format!("({})", pr.created_date()), style);
+    push_pr_field(&mut spans, pr.ci_status(), style);
+    Line::from(spans)
+}
+
+fn review_status_style(pr: &PrNode, fallback: Style) -> Style {
+    match pr.review_decision.as_ref() {
+        Some(prs::ReviewDecision::Approved) => Style::default().fg(Color::Green),
+        Some(prs::ReviewDecision::ChangesRequested) => Style::default().fg(Color::Red),
+        Some(prs::ReviewDecision::ReviewRequired) => Style::default().fg(Color::Yellow),
+        None => fallback,
+    }
+}
+
+fn push_pr_field(spans: &mut Vec<Span<'static>>, text: impl Into<String>, style: Style) {
+    let text = text.into();
+    if text.is_empty() {
+        return;
+    }
+    push_pr_span(spans, Span::styled(text, style), style);
+}
+
+fn push_pr_span(spans: &mut Vec<Span<'static>>, span: Span<'static>, style: Style) {
+    if !spans.is_empty() {
+        spans.push(Span::styled(" ", style));
+    }
+    spans.push(span);
 }
 
 fn build_preview_text(app: &App) -> Text<'static> {

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -1036,7 +1036,6 @@ fn review_status_style(pr: &PrNode, fallback: Style) -> Style {
     }
 }
 
-
 fn push_pr_field(spans: &mut Vec<Span<'static>>, text: impl Into<String>, style: Style) {
     let text = text.into();
     if text.is_empty() {

--- a/src/cmd/tui.rs
+++ b/src/cmd/tui.rs
@@ -1983,6 +1983,70 @@ mod tests {
     }
 
     #[test]
+    fn pr_list_line_skips_empty_optional_fields() {
+        let pr = test_pr("one", 1);
+        let rendered = line_text(&pr_list_line(&pr));
+
+        assert_eq!(rendered, "#1 ✅ owner/repo PR 1 (2026-01-01)");
+    }
+
+    #[test]
+    fn pr_list_line_highlights_review_decision() {
+        for (decision, badge, color) in [
+            (prs::ReviewDecision::Approved, "[approved]", Color::Green),
+            (
+                prs::ReviewDecision::ChangesRequested,
+                "[changes requested]",
+                Color::Red,
+            ),
+            (
+                prs::ReviewDecision::ReviewRequired,
+                "[review required]",
+                Color::Yellow,
+            ),
+        ] {
+            let mut pr = test_pr("one", 1);
+            pr.review_decision = Some(decision);
+            let line = pr_list_line(&pr);
+
+            assert_eq!(span_style(&line, badge), Style::default().fg(color));
+        }
+    }
+
+    #[test]
+    fn pr_list_line_highlights_review_requests() {
+        let pr: PrNode = serde_json::from_value(serde_json::json!({
+            "repository": {
+                "name": "repo",
+                "owner": { "login": "owner" }
+            },
+            "number": 1,
+            "id": "one",
+            "title": "PR 1",
+            "url": "https://github.com/owner/repo/pull/1",
+            "createdAt": "2026-01-01T00:00:00Z",
+            "mergeStateStatus": "CLEAN",
+            "reviewDecision": null,
+            "commits": null,
+            "reviewRequests": {
+                "nodes": [{
+                    "requestedReviewer": {
+                        "__typename": "User",
+                        "login": "alice"
+                    }
+                }]
+            }
+        }))
+        .expect("test PR");
+        let line = pr_list_line(&pr);
+
+        assert_eq!(
+            span_style(&line, "[r: alice]"),
+            Style::default().fg(Color::Yellow)
+        );
+    }
+
+    #[test]
     fn pr_list_marks_dependabot_alert_origin() {
         let mut app = empty_app(AppMode::Prs);
         let mut pr = test_pr("one", 1);
@@ -2003,6 +2067,46 @@ mod tests {
             .map(|cell| cell.symbol())
             .collect::<String>();
         assert!(rendered.contains("[dep-alert]"));
+        let buffer = terminal.backend().buffer();
+        let alert_x = find_row_text_x(buffer, 1, prs::DEPENDABOT_ALERT_BADGE);
+        assert_eq!(buffer[(1, 1)].fg, Color::Green);
+        for x in alert_x..alert_x + prs::DEPENDABOT_ALERT_BADGE.len() as u16 {
+            assert_eq!(buffer[(x, 1)].fg, Color::Cyan);
+        }
+        assert_eq!(
+            buffer[(alert_x + prs::DEPENDABOT_ALERT_BADGE.len() as u16, 1)].fg,
+            Color::Green
+        );
+    }
+
+    fn find_row_text_x(buffer: &ratatui::buffer::Buffer, y: u16, needle: &str) -> u16 {
+        let symbols = needle.chars().map(|c| c.to_string()).collect::<Vec<_>>();
+        let max_x = buffer.area.width.saturating_sub(symbols.len() as u16);
+        for x in 0..=max_x {
+            if symbols
+                .iter()
+                .enumerate()
+                .all(|(i, symbol)| buffer[(x + i as u16, y)].symbol() == symbol)
+            {
+                return x;
+            }
+        }
+        panic!("{needle:?} not found on row {y}");
+    }
+
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect::<String>()
+    }
+
+    fn span_style(line: &Line<'_>, text: &str) -> Style {
+        line.spans
+            .iter()
+            .find(|span| span.content.as_ref() == text)
+            .unwrap_or_else(|| panic!("{text:?} not found in {:?}", line_text(line)))
+            .style
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Render the PR list as structured spans so each field can use its own color
- Highlight review decisions, review requests, and Dependabot alerts more clearly
- Keep the PR list rendering logic testable with focused unit coverage

## Testing
- Added unit tests for list-line rendering, optional-field handling, and field-specific styling
- Extended TUI buffer assertions to verify Dependabot alert badge coloring