### PR TITLE
Bump the minimum supported Rust version to 1.97.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["yasuyuky <yasuyuki.ymd@gmail.com>"]
 edition = "2024"
 name = "gh-chk"
 version = "0.3.0"
-rust-version = "1.97.0"
+rust-version = "1.97.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]


### PR DESCRIPTION
## Summary

- Update the minimum supported Rust version from 1.97.0 to 1.97.1.

## Testing

- Not run (not requested)