### PR TITLE
fix: resolve clippy warnings in PR handling and CLI tests

### DIFF
--- a/src/cmd/prs.rs
+++ b/src/cmd/prs.rs
@@ -175,7 +175,7 @@ impl pull_request::PullRequest {
             let name = &self.review_requests.nodes[0].requested_reviewer;
             format!("[r: {}]", name.as_ref().unwrap())
         } else {
-            format!("[r: {}]", &self.review_requests.nodes.len())
+            format!("[r: {}]", self.review_requests.nodes.len())
         }
     }
     pub(crate) fn review_status(&self) -> String {

--- a/src/cmd/prs.rs
+++ b/src/cmd/prs.rs
@@ -650,7 +650,10 @@ async fn mark_dependabot_alert_origins(
     let mut lookup_errors = Vec::new();
     for chunk in repos.chunks(DEPENDABOT_ALERT_LOOKUP_CONCURRENCY) {
         let mut handles = Vec::with_capacity(chunk.len());
-        for ((owner, name), target_pr_ids) in chunk.iter().cloned() {
+        for ((owner, name), target_pr_ids) in chunk {
+            let owner = owner.clone();
+            let name = name.clone();
+            let target_pr_ids = target_pr_ids.clone();
             let repo = format!("{}/{}", owner, name);
             handles.push((
                 repo,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -56,7 +56,7 @@ fn start_stub() -> StubServer {
     }
 
     let port = reserve_port();
-    let child = Command::new(find_python())
+    let mut child = Command::new(find_python())
         .arg(stub_script())
         .args(["--port", &port.to_string()])
         .stdout(Stdio::null())
@@ -75,6 +75,8 @@ fn start_stub() -> StubServer {
         thread::sleep(Duration::from_millis(50));
     }
 
+    let _ = child.kill();
+    let _ = child.wait();
     panic!("stub server did not start");
 }
 


### PR DESCRIPTION
## Summary

- Remove unnecessary references and cloning flagged by Clippy.
- Ensure the CLI test stub process is cleaned up when startup fails.

## Testing

- Not run (not requested)